### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/rocicorp/zero-virtual/security/code-scanning/9](https://github.com/rocicorp/zero-virtual/security/code-scanning/9)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is constrained to least privilege.  
Best fix here: set workflow-level permissions to `contents: read`, since all shown jobs are test-oriented and only need repository read access (for checkout). This preserves functionality while making permissions explicit and stable across environments.

Edit file **`.github/workflows/test.yml`** by inserting a top-level `permissions:` section between `on:` and `jobs:` (or anywhere at top-level), with:

- `contents: read`

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
