### PR TITLE
feat: support explicit virtualizer count

### DIFF
--- a/src/react/use-zero-virtualizer.test.ts
+++ b/src/react/use-zero-virtualizer.test.ts
@@ -210,4 +210,50 @@ describe('useZeroVirtualizer - virtualizer count and total', () => {
     expect(result.current.total).toBe(expectedTotal);
     expect(result.current.virtualizer.options.count).toBe(expectedCount);
   });
+
+  test('explicit count overrides estimated row count metadata', () => {
+    mockUseRows.mockReturnValue(
+      makeUseRowsResult({
+        rowsLength: 20,
+        complete: false,
+        rowsEmpty: false,
+        atStart: true,
+        atEnd: false,
+        firstRowIndex: 0,
+      }),
+    );
+
+    const options = makeOptions();
+    const {result} = renderHook(() =>
+      useZeroVirtualizer({...options, count: 42}),
+    );
+
+    expect(result.current.virtualizer.options.count).toBe(42);
+    expect(result.current.estimatedTotal).toBe(42);
+    expect(result.current.total).toBe(42);
+    expect(result.current.rowsEmpty).toBe(false);
+  });
+
+  test('explicit zero count reports empty list', () => {
+    mockUseRows.mockReturnValue(
+      makeUseRowsResult({
+        rowsLength: 20,
+        complete: false,
+        rowsEmpty: false,
+        atStart: true,
+        atEnd: false,
+        firstRowIndex: 0,
+      }),
+    );
+
+    const options = makeOptions();
+    const {result} = renderHook(() =>
+      useZeroVirtualizer({...options, count: 0}),
+    );
+
+    expect(result.current.virtualizer.options.count).toBe(0);
+    expect(result.current.estimatedTotal).toBe(0);
+    expect(result.current.total).toBe(0);
+    expect(result.current.rowsEmpty).toBe(true);
+  });
 });

--- a/src/react/use-zero-virtualizer.ts
+++ b/src/react/use-zero-virtualizer.ts
@@ -93,6 +93,9 @@ export type UseZeroVirtualizerOptions<
   /** Parameters that define the list's query context (filters, sort order, etc.) */
   listContextParams: TListContextParams;
 
+  /** Optional exact row count. If provided, it replaces the internally estimated count. */
+  count?: number | undefined;
+
   /** Optional ID to highlight/scroll to a specific row (permalink functionality) */
   permalinkID?: string | null | undefined;
 
@@ -219,6 +222,7 @@ export function useZeroVirtualizer<
 
   // Zero specific params
   listContextParams,
+  count,
   permalinkID,
   getPageQuery,
   getSingleQuery,
@@ -354,15 +358,19 @@ export function useZeroVirtualizer<
   });
 
   const newEstimatedTotal = firstRowIndex + rowsLength;
+  const internalCount =
+    atEnd && atStart && complete
+      ? rowsLength
+      : Math.max(estimatedTotal, newEstimatedTotal) +
+        (!atEnd && rowsLength > 0 ? NUM_ROWS_FOR_LOADING_SKELETON : 0);
+  const effectiveCount = count ?? internalCount;
+  const effectiveEstimatedTotal = count ?? estimatedTotal;
+  const effectiveRowsEmpty = count === undefined ? rowsEmpty : count === 0;
 
   const virtualizer: Virtualizer<TScrollElement, TItemElement> = useVirtualizer(
     {
       ...restVirtualizerOptions,
-      count:
-        atEnd && atStart && complete
-          ? rowsLength
-          : Math.max(estimatedTotal, newEstimatedTotal) +
-            (!atEnd && rowsLength > 0 ? NUM_ROWS_FOR_LOADING_SKELETON : 0),
+      count: effectiveCount,
       estimateSize,
       overscan,
       getScrollElement,
@@ -445,7 +453,7 @@ export function useZeroVirtualizer<
       onScrollStateChange({
         anchor,
         scrollTop: virtualizer.scrollOffset ?? 0,
-        estimatedTotal,
+        estimatedTotal: effectiveEstimatedTotal,
         hasReachedStart,
         hasReachedEnd,
         listContextParams,
@@ -456,7 +464,7 @@ export function useZeroVirtualizer<
   }, [
     anchor,
     virtualizer.scrollOffset,
-    estimatedTotal,
+    effectiveEstimatedTotal,
     hasReachedStart,
     hasReachedEnd,
     isListContextCurrent,
@@ -617,11 +625,12 @@ export function useZeroVirtualizer<
   ]);
 
   const total =
-    atStart && atEnd
+    count ??
+    (atStart && atEnd
       ? rowsLength
       : hasReachedStart && hasReachedEnd
         ? estimatedTotal
-        : undefined;
+        : undefined);
   const virtualItems = virtualizer.getVirtualItems();
 
   useEffect(() => {
@@ -711,9 +720,9 @@ export function useZeroVirtualizer<
     virtualizer,
     rowAt,
     complete,
-    rowsEmpty,
+    rowsEmpty: effectiveRowsEmpty,
     permalinkNotFound,
-    estimatedTotal,
+    estimatedTotal: effectiveEstimatedTotal,
     total,
     settled,
   };


### PR DESCRIPTION
Adds an optional `count` option to `useZeroVirtualizer` for callers that already know the exact row count. This can be fetched outside of Zero.

When provided, `count` now drives:

- TanStack virtualizer `count`
- returned `estimatedTotal`
- returned `total`
- returned `rowsEmpty`