### PR TITLE
feat: Framework-agnostic core + SolidJS bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Live demo at: https://gigabugs.rocicorp.dev/.
 
 Features:
 
+- React and SolidJS bindings over one framework-agnostic core
 - Bidirectional infinite scrolling (load more items at top or bottom)
 - Uniform, non-uniform, or fully dynamic (content-measured) row heights
 - Element scrolling or window scrolling (`useZeroWindowVirtualizer`)
@@ -32,6 +33,19 @@ Features:
 - Without `count`, the scrollbar is approximate: off-screen extent is sized
   from `estimateSize` and grows as rows are discovered (as with any virtualized
   list of unknown length). Visible content is always positioned exactly.
+
+## Entry points
+
+- **`@rocicorp/zero-virtual/react`** — the React hooks (this guide).
+- **`@rocicorp/zero-virtual/solid`** — the SolidJS bindings:
+  `createZeroVirtualizer` / `createZeroWindowVirtualizer`,
+  `createHistoryScrollState`, `createStickToBottom`. Same options and
+  snapshot shape as React, with accessors in the reactive slots (query
+  functions are bound via `@rocicorp/zero/solid`).
+- **`@rocicorp/zero-virtual/core`** — the framework-agnostic
+  `ZeroVirtualizer` the wrappers share. **Experimental: this entry point is
+  public so you can build bindings for other frameworks, but its API may
+  change in breaking ways in any release while it settles.**
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Features:
 ## Restrictions
 
 - Vertical lists only.
+- **Browser support: Chromium 114+, Firefox 109+, Safari 26+.** The floor is
+  the native `scrollend` event, which the manual anchoring relies on to
+  reconcile momentum-time corrections at the end of a touch gesture (there is
+  deliberately no timer-based fallback for older engines).
 - In `native` anchoring mode, relies on the browser's CSS `overflow-anchor`
   (Chromium and Firefox; Safari doesn't implement it). The default `auto` mode
   feature-detects and falls back to `manual`, which implements the equivalent

--- a/demo/App.tsx
+++ b/demo/App.tsx
@@ -50,7 +50,7 @@ export function App(): React.ReactNode {
   const getPageQuery = useGetPageQuery(listContextParams);
   const [scrollState, onScrollStateChange] = useHistoryScrollState<ItemStart>();
 
-  const {items, spaceBefore, spaceAfter, estimatedTotal, total, debug} =
+  const {items, spaceBefore, spaceAfter, estimatedTotal, total} =
     useZeroVirtualizer({
       listContextParams,
       getScrollElement,
@@ -105,7 +105,6 @@ export function App(): React.ReactNode {
         <ItemDetail id={permalinkID} onClose={() => setHash('')} />
       )}
       <DevPanel
-        debug={debug}
         getScrollElement={getScrollElement}
         heightMode={heightMode}
         onHeightModeChange={setHeightMode}

--- a/demo/DevPanel.tsx
+++ b/demo/DevPanel.tsx
@@ -4,11 +4,6 @@ import styles from './DevPanel.module.css';
 import type {HeightMode} from './list-shared.ts';
 import {useUrlState} from './use-url-state.ts';
 
-type DebugState = {
-  isScrolling: boolean;
-  pendingJump: number;
-};
-
 /**
  * The collapsible dev panel from the design handoff: all demo configuration
  * (scroll container, item sizing, add-item actions), the virtualizer's live
@@ -17,7 +12,6 @@ type DebugState = {
  * re-renders the list.
  */
 export function DevPanel({
-  debug,
   getScrollElement,
   windowMode = false,
   heightMode,
@@ -28,7 +22,6 @@ export function DevPanel({
   follow,
   onFollowChange,
 }: {
-  debug: {readonly current: DebugState};
   getScrollElement: () => HTMLElement | null;
   windowMode?: boolean;
   heightMode: HeightMode;
@@ -43,10 +36,7 @@ export function DevPanel({
   // The scroll-container mode lives in the URL (it selects which demo renders).
   const [scroller, setScroller] = useUrlState('scroller', 'element');
 
-  const [snap, setSnap] = useState<DebugState & {st: number}>({
-    st: 0,
-    ...debug.current,
-  });
+  const [snap, setSnap] = useState({st: 0});
   const raf = useRef(0);
   useEffect(() => {
     if (!open) return undefined;
@@ -57,12 +47,12 @@ export function DevPanel({
         : el
           ? Math.round(el.scrollTop)
           : 0;
-      setSnap({st, ...debug.current});
+      setSnap({st});
       raf.current = requestAnimationFrame(tick);
     };
     raf.current = requestAnimationFrame(tick);
     return () => cancelAnimationFrame(raf.current);
-  }, [open, debug, getScrollElement, windowMode]);
+  }, [open, getScrollElement, windowMode]);
 
   if (!open) {
     return (
@@ -120,18 +110,6 @@ export function DevPanel({
         <div className={styles.statRow}>
           <span className={styles.statName}>scrollTop</span>
           <span className={styles.statValue}>{snap.st}</span>
-        </div>
-        <div className={styles.statRow}>
-          <span className={styles.statName}>scrolling</span>
-          <span className={styles.statValue}>
-            {snap.isScrolling ? 'yes' : 'no'}
-          </span>
-        </div>
-        <div className={styles.statRow}>
-          <span className={styles.statName}>pending</span>
-          <span className={styles.statValue}>
-            {Math.round(snap.pendingJump)}
-          </span>
         </div>
       </div>
 

--- a/demo/WindowList.tsx
+++ b/demo/WindowList.tsx
@@ -57,7 +57,7 @@ export function WindowList(): React.ReactNode {
   const getPageQuery = useGetPageQuery(listContextParams);
   const [scrollState, onScrollStateChange] = useHistoryScrollState<ItemStart>();
 
-  const {items, spaceBefore, spaceAfter, estimatedTotal, total, debug} =
+  const {items, spaceBefore, spaceAfter, estimatedTotal, total} =
     useZeroWindowVirtualizer({
       listContextParams,
       getScrollElement,
@@ -106,7 +106,6 @@ export function WindowList(): React.ReactNode {
         <Spacer height={spaceAfter} />
       </div>
       <DevPanel
-        debug={debug}
         getScrollElement={getScrollElement}
         windowMode
         heightMode={heightMode}

--- a/demo/package.json
+++ b/demo/package.json
@@ -28,6 +28,7 @@
     "playwright-core": "^1.61.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "solid-js": "^1.9.14",
     "vite": "^8.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,14 @@
     "./react": {
       "types": "./dist/react/index.d.ts",
       "import": "./dist/react/index.js"
+    },
+    "./solid": {
+      "types": "./dist/solid/index.d.ts",
+      "import": "./dist/solid/index.js"
+    },
+    "./core": {
+      "types": "./dist/core/index.d.ts",
+      "import": "./dist/core/index.js"
     }
   },
   "scripts": {
@@ -51,13 +59,26 @@
     "oxlint-tsgolint": "^0.17.4",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "solid-js": "^1.9.14",
     "vite": "^8.0.3",
     "vitest": "^4.1.2"
   },
   "peerDependencies": {
     "@rocicorp/zero": "1.7.0",
     "react": "^19.2.4",
-    "react-dom": "^19.2.4"
+    "react-dom": "^19.2.4",
+    "solid-js": "^1.9.4"
   },
-  "packageManager": "pnpm@11.1.3"
+  "packageManager": "pnpm@11.1.3",
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
+    "react-dom": {
+      "optional": true
+    },
+    "solid-js": {
+      "optional": true
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "react-dom": "^19.2.4",
     "solid-js": "^1.9.4"
   },
-  "packageManager": "pnpm@11.1.3",
   "peerDependenciesMeta": {
     "react": {
       "optional": true
@@ -80,5 +79,6 @@
     "solid-js": {
       "optional": true
     }
-  }
+  },
+  "packageManager": "pnpm@11.1.3"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ importers:
     devDependencies:
       '@rocicorp/zero':
         specifier: 1.7.0
-        version: 1.7.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(pg@8.20.0)(react@19.2.4)
+        version: 1.7.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(pg@8.20.0)(react@19.2.4)(solid-js@1.9.14)
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -45,6 +45,9 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+      solid-js:
+        specifier: ^1.9.14
+        version: 1.9.14
       vite:
         specifier: ^8.0.3
         version: 8.0.3(@types/node@25.5.0)(yaml@2.9.0)
@@ -59,7 +62,7 @@ importers:
         version: 1.19.11(hono@4.12.9)
       '@rocicorp/zero':
         specifier: 1.7.0
-        version: 1.7.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(pg@8.20.0)(react@19.2.4)
+        version: 1.7.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(pg@8.20.0)(react@19.2.4)(solid-js@1.9.14)
       '@rocicorp/zero-virtual':
         specifier: workspace:*
         version: link:..
@@ -94,6 +97,9 @@ importers:
       react-dom:
         specifier: ^19.2.4
         version: 19.2.4(react@19.2.4)
+      solid-js:
+        specifier: ^1.9.14
+        version: 1.9.14
       vite:
         specifier: ^8.0.3
         version: 8.0.3(@types/node@25.5.0)(yaml@2.9.0)
@@ -2461,6 +2467,16 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  seroval-plugins@1.5.4:
+    resolution: {integrity: sha512-S0xQPhUTefAhNvNWFg0c1J8qJArHt5KdtJ/cFAofo06KD1MVSeFWyl4iiu+ApDIuw0WhjpOfCdgConOfAnLgkw==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      seroval: ^1.0
+
+  seroval@1.5.4:
+    resolution: {integrity: sha512-46uFvgrXTVxZcUorgSSRZ4y+ieqLLQRMlG4bnCZKW3qI6BZm7Rg4ntMW4p1mILEEBZWrFlcpp0AyIIlM6jD9iw==}
+    engines: {node: '>=10'}
+
   set-cookie-parser@2.7.2:
     resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
 
@@ -2494,6 +2510,9 @@ packages:
 
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
+
+  solid-js@1.9.14:
+    resolution: {integrity: sha512-sAEXC0Kk0S1EDg+8ysEWJDbYhA3RRoEjwuySUGlKIemeo0I5YZfOyumNjNs9Sv3y2nmhD+0rW66ag2HsMuQiGQ==}
 
   sonic-boom@4.2.1:
     resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
@@ -3871,7 +3890,7 @@ snapshots:
       bindings: 1.5.0
       prebuild-install: 7.1.3
 
-  '@rocicorp/zero@1.7.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(pg@8.20.0)(react@19.2.4)':
+  '@rocicorp/zero@1.7.0(@opentelemetry/core@2.8.0(@opentelemetry/api@1.9.0))(pg@8.20.0)(react@19.2.4)(solid-js@1.9.14)':
     dependencies:
       '@badrap/valita': 0.3.11
       '@databases/escape-identifier': 1.0.3
@@ -3925,6 +3944,7 @@ snapshots:
     optionalDependencies:
       pg: 8.20.0
       react: 19.2.4
+      solid-js: 1.9.14
     transitivePeerDependencies:
       - '@75lb/nature'
       - '@opentelemetry/core'
@@ -5147,6 +5167,12 @@ snapshots:
 
   semver@7.7.4: {}
 
+  seroval-plugins@1.5.4(seroval@1.5.4):
+    dependencies:
+      seroval: 1.5.4
+
+  seroval@1.5.4: {}
+
   set-cookie-parser@2.7.2: {}
 
   set-function-length@1.2.2:
@@ -5179,6 +5205,12 @@ snapshots:
       decompress-response: 6.0.0
       once: 1.4.0
       simple-concat: 1.0.1
+
+  solid-js@1.9.14:
+    dependencies:
+      csstype: 3.2.3
+      seroval: 1.5.4
+      seroval-plugins: 1.5.4(seroval@1.5.4)
 
   sonic-boom@4.2.1:
     dependencies:

--- a/src/core/dom.ts
+++ b/src/core/dom.ts
@@ -1,0 +1,47 @@
+import type {RowKey} from './types.ts';
+
+// The row-identification contract between the virtualizer and the rendered
+// rows: every row element (including loading placeholders) carries these two
+// attributes — they are how the virtualizer finds rows in the DOM (visible-row
+// detection for paging, the anchoring reference, permalink targets). Consumers
+// should spread {@linkcode rowAttributes} onto each row element.
+export const VROW_INDEX_ATTR = 'data-vrow-index';
+export const VROW_KEY_ATTR = 'data-vrow-key';
+
+/**
+ * The attributes every rendered row (and loading placeholder) must carry, as an
+ * object to spread onto the row element: `<div {...rowAttributes(index, key)}>`.
+ * See {@linkcode VirtualRow} for `index` / `key`.
+ */
+export function rowAttributes(
+  index: number,
+  key: RowKey,
+): {'data-vrow-index': number; 'data-vrow-key': RowKey} {
+  return {[VROW_INDEX_ATTR]: index, [VROW_KEY_ATTR]: key};
+}
+
+/** All rendered row elements inside the container, in DOM order. */
+export function queryRows(el: HTMLElement): Iterable<HTMLElement> {
+  return el.querySelectorAll<HTMLElement>(`[${VROW_INDEX_ATTR}]`);
+}
+
+/** The first rendered row element (the held-margin carrier), or null. */
+export function firstRow(el: HTMLElement): HTMLElement | null {
+  return el.querySelector<HTMLElement>(`[${VROW_INDEX_ATTR}]`);
+}
+
+/** Find a rendered row element by its stable key. */
+export function findRow(el: HTMLElement, key: RowKey): HTMLElement | null {
+  return el.querySelector<HTMLElement>(
+    `[${VROW_KEY_ATTR}="${CSS.escape(String(key))}"]`,
+  );
+}
+
+/** Whether a client-coordinate rect overlaps the `[top, bottom)` viewport band. */
+export function rectInViewport(
+  rect: DOMRect,
+  top: number,
+  bottom: number,
+): boolean {
+  return rect.bottom > top && rect.top < bottom;
+}

--- a/src/core/history-state.ts
+++ b/src/core/history-state.ts
@@ -1,0 +1,40 @@
+/**
+ * A framework-free external store over the Navigation API's current-entry
+ * state: subscribe / snapshot / update. The React wrapper bridges it with
+ * `useSyncExternalStore`; the Solid wrapper with a signal.
+ */
+
+let currentSnapshot: unknown = null;
+let currentSnapshotString = 'null';
+
+/**
+ * The current history-entry state. Cached by JSON identity so an unchanged
+ * state returns the same object (required by `useSyncExternalStore`, and what
+ * keeps downstream memoization stable).
+ */
+export function getHistoryStateSnapshot(): unknown {
+  const newSnapshot = navigation.currentEntry?.getState();
+  const newSnapshotString = JSON.stringify(newSnapshot);
+  if (newSnapshotString !== currentSnapshotString) {
+    currentSnapshot = newSnapshot;
+    currentSnapshotString = newSnapshotString;
+  }
+  return currentSnapshot;
+}
+
+/** Server-side snapshot (no Navigation API): always null. */
+export function getHistoryStateServerSnapshot(): unknown {
+  return null;
+}
+
+/** Replace the current history entry's state. */
+export function updateHistoryState(state: unknown): void {
+  navigation.updateCurrentEntry({state});
+}
+
+/** Listen for current-entry changes; returns an unsubscribe fn. */
+export function subscribeHistoryState(onStoreChange: () => void): () => void {
+  navigation.addEventListener('currententrychange', onStoreChange);
+  return () =>
+    navigation.removeEventListener('currententrychange', onStoreChange);
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,0 +1,53 @@
+/**
+ * Framework-agnostic core of `@rocicorp/zero-virtual`.
+ *
+ * @experimental This entry point is public but UNSTABLE: it exists so
+ * framework wrappers (react, solid, yours) can share one implementation, and
+ * its API may change in breaking ways in any release while it settles. The
+ * `./react` and `./solid` entry points are the stable surfaces.
+ */
+export {
+  findRow,
+  firstRow,
+  queryRows,
+  rowAttributes,
+  VROW_INDEX_ATTR,
+  VROW_KEY_ATTR,
+} from './dom.ts';
+export {
+  getHistoryStateServerSnapshot,
+  getHistoryStateSnapshot,
+  subscribeHistoryState,
+  updateHistoryState,
+} from './history-state.ts';
+export {
+  assembleRows,
+  buildAfterQuery,
+  buildMainQuery,
+  buildSingleQuery,
+  permalinkMissing,
+  type RowsQueryInputs,
+  type RowsQueryResults,
+  type RowsSnapshot,
+} from './rows.ts';
+export {
+  elementScrollAdapter,
+  windowScrollAdapter,
+  type ScrollAdapter,
+  type ScrollRect,
+} from './scroll-adapter.ts';
+export type {
+  Anchor,
+  AnchoringMode,
+  GetPageQuery,
+  GetPageQueryOptions,
+  GetQueryReturnType,
+  GetSingleQuery,
+  GetSingleQueryOptions,
+  QueryOptions,
+  QueryResult,
+  RowKey,
+  ScrollHistoryState,
+  TTL,
+  VirtualRow,
+} from './types.ts';

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -31,6 +31,16 @@ export {
   type RowsSnapshot,
 } from './rows.ts';
 export {
+  createStickToBottom,
+  DEFAULT_STICK_SLACK,
+  type StickToBottomController,
+} from './stick-to-bottom.ts';
+export {
+  ZeroVirtualizer,
+  type VirtualizerOptions,
+  type VirtualizerSnapshot,
+} from './virtualizer.ts';
+export {
   elementScrollAdapter,
   windowScrollAdapter,
   type ScrollAdapter,

--- a/src/core/rows.ts
+++ b/src/core/rows.ts
@@ -124,7 +124,9 @@ export function permalinkMissing<TRow, TStartRow>(
   singleRow: TRow | undefined,
   singleComplete: boolean,
 ): boolean {
-  return isPermalink(inputs.anchor) && singleComplete && singleRow === undefined;
+  return (
+    isPermalink(inputs.anchor) && singleComplete && singleRow === undefined
+  );
 }
 
 /**
@@ -201,8 +203,7 @@ export function assembleRows<TRow, TStartRow>(
         singleRow === undefined ||
         (rowsBeforeSize === 0 && rowsAfterSize === 0),
       atStart:
-        permalinkNotFound ||
-        (mainComplete && rowsBeforeLength <= halfPageSize),
+        permalinkNotFound || (mainComplete && rowsBeforeLength <= halfPageSize),
       atEnd:
         permalinkNotFound ||
         (afterComplete && rowsAfterLength <= halfPageSize - 1),

--- a/src/core/rows.ts
+++ b/src/core/rows.ts
@@ -1,0 +1,244 @@
+import {assert, unreachable} from '../asserts.ts';
+import type {
+  Anchor,
+  GetPageQuery,
+  GetSingleQuery,
+  QueryResult,
+} from './types.ts';
+
+/**
+ * The inputs that determine which queries the virtualizer needs. Produced by
+ * the core, consumed by the framework wrappers, which feed them into their
+ * framework's Zero query binding and return the results via
+ * {@linkcode assembleRows}.
+ */
+export type RowsQueryInputs<TStartRow> = {
+  pageSize: number;
+  anchor: Anchor<TStartRow>;
+  settled: boolean;
+};
+
+/**
+ * The assembled, framework-free view over the loaded rows — what the
+ * virtualizer consumes. (The return shape of the framework `useRows` hooks.)
+ */
+export type RowsSnapshot<TRow> = {
+  rowAt: (index: number) => TRow | undefined;
+  rowsLength: number;
+  complete: boolean;
+  rowsEmpty: boolean;
+  atStart: boolean;
+  atEnd: boolean;
+  firstRowIndex: number;
+  permalinkNotFound: boolean;
+};
+
+/** The raw results of the (up to) three staged queries. */
+export type RowsQueryResults<TRow> = {
+  /** Single-row permalink lookup result (undefined while loading). */
+  singleRow: TRow | undefined;
+  singleComplete: boolean;
+  /** Page-before rows (permalink) or the main page rows (forward/backward). */
+  mainRows: TRow[] | undefined;
+  mainComplete: boolean;
+  /** Page-after rows (permalink only). */
+  afterRows: TRow[] | undefined;
+  afterComplete: boolean;
+};
+
+function isPermalink<TStartRow>(
+  anchor: Anchor<TStartRow>,
+): anchor is Extract<Anchor<TStartRow>, {kind: 'permalink'}> {
+  return anchor.kind === 'permalink';
+}
+
+/**
+ * Stage 1: the single-row lookup (permalink anchors only; null otherwise so
+ * wrappers can keep a stable query slot).
+ */
+export function buildSingleQuery<TRow, TStartRow>(
+  inputs: RowsQueryInputs<TStartRow>,
+  getSingleQuery: GetSingleQuery<TRow>,
+): QueryResult<TRow | undefined> | null {
+  return isPermalink(inputs.anchor)
+    ? getSingleQuery({id: inputs.anchor.id, settled: inputs.settled})
+    : null;
+}
+
+/**
+ * Stage 2: the main page query — page-before rows for a permalink (depends on
+ * stage 1's result), or the whole page for forward/backward anchors.
+ */
+export function buildMainQuery<TRow, TStartRow>(
+  inputs: RowsQueryInputs<TStartRow>,
+  getPageQuery: GetPageQuery<TRow, TStartRow>,
+  singleStart: TStartRow | null,
+  permalinkNotFound: boolean,
+): QueryResult<TRow> | null {
+  const {anchor, pageSize, settled} = inputs;
+  if (isPermalink(anchor)) {
+    assert(pageSize % 2 === 0);
+    return !permalinkNotFound && singleStart
+      ? getPageQuery({
+          limit: pageSize / 2 + 1,
+          start: singleStart,
+          dir: 'backward',
+          settled,
+        })
+      : null;
+  }
+  return getPageQuery({
+    limit: pageSize + 1,
+    start: anchor.startRow ?? null,
+    dir: anchor.kind,
+    settled,
+  });
+}
+
+/**
+ * Stage 3: the page-after query (permalink anchors only; depends on stage 1's
+ * result).
+ */
+export function buildAfterQuery<TRow, TStartRow>(
+  inputs: RowsQueryInputs<TStartRow>,
+  getPageQuery: GetPageQuery<TRow, TStartRow>,
+  singleStart: TStartRow | null,
+  permalinkNotFound: boolean,
+): QueryResult<TRow> | null {
+  const {anchor, pageSize, settled} = inputs;
+  if (!isPermalink(anchor)) return null;
+  assert(pageSize % 2 === 0);
+  return !permalinkNotFound && singleStart
+    ? getPageQuery({
+        limit: pageSize / 2,
+        start: singleStart,
+        dir: 'forward',
+        settled,
+      })
+    : null;
+}
+
+/** Whether a permalink anchor's target row is complete-and-missing. */
+export function permalinkMissing<TRow, TStartRow>(
+  inputs: RowsQueryInputs<TStartRow>,
+  singleRow: TRow | undefined,
+  singleComplete: boolean,
+): boolean {
+  return isPermalink(inputs.anchor) && singleComplete && singleRow === undefined;
+}
+
+/**
+ * Assemble the framework-free rows view from the staged query results. Pure —
+ * the framework wrappers own query subscription and staging; this owns all
+ * the windowing math.
+ */
+export function assembleRows<TRow, TStartRow>(
+  inputs: RowsQueryInputs<TStartRow>,
+  results: RowsQueryResults<TRow>,
+): RowsSnapshot<TRow> {
+  const {anchor, pageSize} = inputs;
+  const {kind, index: anchorIndex} = anchor;
+  const halfPageSize = pageSize / 2;
+  const {
+    singleRow,
+    singleComplete,
+    mainRows,
+    mainComplete,
+    afterRows,
+    afterComplete,
+  } = results;
+
+  const permalinkNotFound = permalinkMissing(inputs, singleRow, singleComplete);
+
+  const rowsBeforeLength = mainRows?.length ?? 0;
+  const rowsAfterLength = afterRows?.length ?? 0;
+  const rowsBeforeSize = Math.min(rowsBeforeLength, halfPageSize);
+  const rowsAfterSize = Math.min(rowsAfterLength, halfPageSize - 1);
+
+  const pageRows = mainRows ?? [];
+  const hasMoreRows = kind !== 'permalink' && pageRows.length > pageSize;
+  const paginatedRowsLength = hasMoreRows ? pageSize : pageRows.length;
+
+  const rowAt = (index: number): TRow | undefined => {
+    switch (kind) {
+      case 'permalink': {
+        if (index === anchorIndex) {
+          return singleRow;
+        }
+        if (index > anchorIndex) {
+          if (afterRows === undefined) return undefined;
+          const i = index - anchorIndex - 1;
+          return i < rowsAfterSize ? afterRows[i] : undefined;
+        }
+        if (mainRows === undefined) return undefined;
+        const i = anchorIndex - index - 1;
+        return i < rowsBeforeSize ? mainRows[i] : undefined;
+      }
+      case 'forward': {
+        const i = index - anchorIndex;
+        return i >= 0 && i < paginatedRowsLength ? pageRows[i] : undefined;
+      }
+      case 'backward': {
+        const i = anchorIndex - index - 1;
+        return i >= 0 && i < paginatedRowsLength ? pageRows[i] : undefined;
+      }
+      default:
+        unreachable(kind);
+    }
+  };
+
+  if (kind === 'permalink') {
+    return {
+      rowAt,
+      rowsLength: permalinkNotFound
+        ? 0
+        : rowsBeforeSize + rowsAfterSize + (singleRow ? 1 : 0),
+      complete:
+        singleComplete &&
+        (permalinkNotFound || (mainComplete && afterComplete)),
+      rowsEmpty:
+        permalinkNotFound ||
+        singleRow === undefined ||
+        (rowsBeforeSize === 0 && rowsAfterSize === 0),
+      atStart:
+        permalinkNotFound ||
+        (mainComplete && rowsBeforeLength <= halfPageSize),
+      atEnd:
+        permalinkNotFound ||
+        (afterComplete && rowsAfterLength <= halfPageSize - 1),
+      firstRowIndex: permalinkNotFound
+        ? anchorIndex
+        : anchorIndex - rowsBeforeSize,
+      permalinkNotFound,
+    };
+  }
+
+  const pageStart = anchor.startRow ?? null;
+
+  if (kind === 'forward') {
+    return {
+      rowAt,
+      rowsLength: paginatedRowsLength,
+      complete: mainComplete,
+      rowsEmpty: pageRows.length === 0,
+      atStart: pageStart === null || anchorIndex === 0,
+      atEnd: mainComplete && !hasMoreRows,
+      firstRowIndex: anchorIndex,
+      permalinkNotFound,
+    };
+  }
+
+  kind satisfies 'backward';
+  assert(pageStart !== null);
+
+  return {
+    rowAt,
+    rowsLength: paginatedRowsLength,
+    complete: mainComplete,
+    rowsEmpty: pageRows.length === 0,
+    atStart: mainComplete && !hasMoreRows,
+    atEnd: false,
+    firstRowIndex: anchorIndex - paginatedRowsLength,
+    permalinkNotFound,
+  };
+}

--- a/src/core/scroll-adapter.ts
+++ b/src/core/scroll-adapter.ts
@@ -56,9 +56,7 @@ export const elementScrollAdapter: ScrollAdapter = {
 
 /** Scroll adapter for a list that scrolls the window. */
 export const windowScrollAdapter: ScrollAdapter = {
-  scrollElement: () =>
-    (document.scrollingElement as HTMLElement | null) ??
-    document.documentElement,
+  scrollElement: () => document.scrollingElement as HTMLElement,
   viewportTop: () => 0,
   subscribe: (_el, onScroll, onScrollEnd) => {
     window.addEventListener('scroll', onScroll, {passive: true});

--- a/src/core/scroll-adapter.ts
+++ b/src/core/scroll-adapter.ts
@@ -1,0 +1,71 @@
+/** The size of the scroll viewport. */
+export type ScrollRect = {width: number; height: number};
+
+/**
+ * Abstracts the scroll container so the same virtualizer works whether the list
+ * scrolls inside an element or scrolls the window. Mirrors the split TanStack
+ * Virtual makes between its `element*` and `window*` scroll helpers.
+ *
+ * `el` is always the element the rows are rendered into (returned by
+ * `getScrollElement`). For element scrolling it is also the scroll container;
+ * for window scrolling the window is the scroll container and `el` is only used
+ * to locate the rendered rows.
+ */
+export type ScrollAdapter = {
+  /**
+   * The actual scrolling element: the overflow container itself for element
+   * scrolling, `document.scrollingElement` for window scrolling. Everything
+   * positional is derived from it — scroll offset (`scrollTop`), viewport size
+   * (`clientWidth`/`clientHeight`), content extent (`scrollHeight`),
+   * `overflow-anchor` toggling, and touch listeners (touches bubble to it).
+   */
+  scrollElement: (el: HTMLElement) => HTMLElement;
+  /**
+   * Top of the scroll viewport in client (getBoundingClientRect) coordinates;
+   * 0 for the window scroller. Row positions are measured against this. (The
+   * nearest TanStack Virtual concept is `scrollMargin`, but that is a static
+   * offset from the scroll origin rather than a client coordinate, so the name
+   * is not borrowed.)
+   */
+  viewportTop: (el: HTMLElement) => number;
+  /**
+   * Listen for `scroll` / `scrollend` on the scroll container (these don't
+   * bubble, so where to listen is adapter-specific: the element itself vs. the
+   * window). Returns an unsubscribe fn.
+   */
+  subscribe: (
+    el: HTMLElement,
+    onScroll: () => void,
+    onScrollEnd: () => void,
+  ) => () => void;
+};
+
+/** Scroll adapter for a list that scrolls inside an overflow element. */
+export const elementScrollAdapter: ScrollAdapter = {
+  scrollElement: el => el,
+  viewportTop: el => el.getBoundingClientRect().top,
+  subscribe: (el, onScroll, onScrollEnd) => {
+    el.addEventListener('scroll', onScroll, {passive: true});
+    el.addEventListener('scrollend', onScrollEnd);
+    return () => {
+      el.removeEventListener('scroll', onScroll);
+      el.removeEventListener('scrollend', onScrollEnd);
+    };
+  },
+};
+
+/** Scroll adapter for a list that scrolls the window. */
+export const windowScrollAdapter: ScrollAdapter = {
+  scrollElement: () =>
+    (document.scrollingElement as HTMLElement | null) ??
+    document.documentElement,
+  viewportTop: () => 0,
+  subscribe: (_el, onScroll, onScrollEnd) => {
+    window.addEventListener('scroll', onScroll, {passive: true});
+    window.addEventListener('scrollend', onScrollEnd);
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      window.removeEventListener('scrollend', onScrollEnd);
+    };
+  },
+};

--- a/src/core/stick-to-bottom.ts
+++ b/src/core/stick-to-bottom.ts
@@ -1,0 +1,68 @@
+import type {ScrollAdapter} from './scroll-adapter.ts';
+
+/**
+ * Slack (px) around the bottom edge so sub-pixel rounding or a stray
+ * fractional scroll position doesn't count as "not at the bottom".
+ */
+export const DEFAULT_STICK_SLACK = 4;
+
+export type StickToBottomController = {
+  /**
+   * Call after content may have grown at the bottom (post-DOM-update,
+   * pre-paint). Re-pins to the bottom if the user was parked there; attaches
+   * the scroll listener lazily once the element exists.
+   */
+  contentChanged(): void;
+  /** Remove listeners. Safe to call repeatedly. */
+  detach(): void;
+};
+
+/**
+ * The framework-free heart of stick-to-bottom: track "is the user parked at
+ * the bottom?" on every scroll (i.e. *before* content grows, which is the
+ * whole trick), and snap back to the bottom on content growth only while
+ * stuck. Starts unstuck; the first measurement decides (a freshly mounted
+ * short list measures as at-bottom, so a chat still starts stuck, while a
+ * restored mid-list position is never yanked).
+ */
+export function createStickToBottom(
+  getScrollElement: () => HTMLElement | null,
+  adapter: ScrollAdapter,
+  slack: number = DEFAULT_STICK_SLACK,
+): StickToBottomController {
+  let stuck = false;
+  let attachedEl: HTMLElement | null = null;
+  let unsubscribe: (() => void) | null = null;
+
+  const ensureAttached = (): HTMLElement | null => {
+    const el = getScrollElement();
+    if (el === attachedEl) return el;
+    unsubscribe?.();
+    unsubscribe = null;
+    attachedEl = el;
+    if (!el) return null;
+    const scroller = adapter.scrollElement(el);
+    const measure = () => {
+      stuck =
+        scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight <=
+        slack;
+    };
+    measure();
+    unsubscribe = adapter.subscribe(el, measure, () => {});
+    return el;
+  };
+
+  return {
+    contentChanged() {
+      const el = ensureAttached();
+      if (!el || !stuck) return;
+      const scroller = adapter.scrollElement(el);
+      scroller.scrollTop = scroller.scrollHeight;
+    },
+    detach() {
+      unsubscribe?.();
+      unsubscribe = null;
+      attachedEl = null;
+    },
+  };
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,0 +1,172 @@
+import type {
+  DefaultContext,
+  DefaultSchema,
+  QueryOrQueryRequest,
+} from '@rocicorp/zero';
+
+/**
+ * Zero's query time-to-live. Replicated structurally (`@rocicorp/zero` doesn't
+ * export it from its root entry, and this package's core must stay
+ * framework-free) — assignable to the `ttl` of both the react and solid
+ * `UseQueryOptions`.
+ */
+export type TTL =
+  | `${number}${'s' | 'm' | 'h' | 'd' | 'y'}`
+  | 'forever'
+  | 'none'
+  | number;
+
+/**
+ * Stable per-row key (row id when loaded, index-derived otherwise). Kept
+ * framework-free — assignable to React's `Key` and usable directly in Solid.
+ */
+export type RowKey = string | number;
+
+/**
+ * Represents a position in the virtualized list used for pagination.
+ *
+ * @typeParam TStartRow - The type of data needed to anchor pagination
+ */
+export type Anchor<TStartRow> =
+  | Readonly<{
+      index: number;
+      kind: 'forward';
+      startRow?: TStartRow | undefined;
+    }>
+  | Readonly<{
+      index: number;
+      kind: 'backward';
+      startRow: TStartRow;
+    }>
+  | Readonly<{
+      index: number;
+      kind: 'permalink';
+      id: string;
+    }>;
+
+/**
+ * Per-query options, framework-free. Structurally assignable to the
+ * `UseQueryOptions` of both `@rocicorp/zero/react` and `@rocicorp/zero/solid`.
+ */
+export type QueryOptions = {
+  enabled?: boolean | undefined;
+  ttl?: TTL | undefined;
+};
+
+/** Result returned by query functions: a query plus optional per-query options. */
+export type QueryResult<TReturn> = {
+  query: GetQueryReturnType<TReturn>;
+  options?: QueryOptions;
+};
+
+/**
+ * Options passed to {@link GetPageQuery}.
+ *
+ * @typeParam TStartRow - The type of data needed to anchor pagination
+ */
+export type GetPageQueryOptions<TStartRow> = {
+  /** The maximum number of rows to return */
+  limit: number;
+  /** The start row data to anchor the query, or null if starting from the beginning */
+  start: TStartRow | null;
+  /** The direction to paginate ('forward' or 'backward') */
+  dir: 'forward' | 'backward';
+  /** Whether the list has been idle for `settleTime` ms */
+  settled: boolean;
+};
+
+/**
+ * Function that returns a query for fetching a page of rows.
+ *
+ * @typeParam TRow - The type of row data returned from queries
+ * @typeParam TStartRow - The type of data needed to anchor pagination
+ */
+export type GetPageQuery<TRow, TStartRow> = (
+  options: GetPageQueryOptions<TStartRow>,
+) => QueryResult<TRow>;
+
+/**
+ * Options passed to {@link GetSingleQuery}.
+ */
+export type GetSingleQueryOptions = {
+  /** The ID of the row to fetch */
+  id: string;
+  /** Whether the list has been idle for `settleTime` ms */
+  settled: boolean;
+};
+
+/**
+ * Function that returns a query for fetching a single row by ID.
+ *
+ * @typeParam TRow - The type of row data returned from queries
+ */
+export type GetSingleQuery<TRow> = (
+  options: GetSingleQueryOptions,
+) => QueryResult<TRow | undefined>;
+
+/**
+ * Return type of a Zero query or query request.
+ *
+ * @typeParam TReturn - The type of the query return value
+ */
+export type GetQueryReturnType<TReturn> = QueryOrQueryRequest<
+  keyof DefaultSchema['tables'] & string,
+  // oxlint-disable-next-line no-explicit-any
+  any, // input
+  // oxlint-disable-next-line no-explicit-any
+  any, // output
+  DefaultSchema,
+  TReturn,
+  DefaultContext
+>;
+
+/**
+ * A single item to render. Rows are rendered in normal document flow (no
+ * absolute positioning), so there is no `start`/`size` — the browser lays them
+ * out.
+ *
+ * @typeParam TRow - The type of row data returned from queries
+ */
+export type VirtualRow<TRow> = {
+  /** The row's index in the (estimated) full list. */
+  index: number;
+  /** Stable key for rendering. Row id when loaded, otherwise index-derived. */
+  key: RowKey;
+  /** The row data, or undefined while the row is still loading. */
+  row: TRow | undefined;
+};
+
+/**
+ * How the viewport is kept stable as off-screen content resizes:
+ * - `native`: rely on the browser's CSS `overflow-anchor` (simplest; used where
+ *   it's reliable).
+ * - `manual`: the momentum-safe manual anchoring (reference-row pinning, with
+ *   touch-time corrections held as a first-row margin), for browsers without
+ *   native scroll anchoring.
+ * - `auto`: feature-detect `overflow-anchor` support (default).
+ */
+export type AnchoringMode = 'auto' | 'manual' | 'native';
+
+/**
+ * State object that captures the virtualizer's scroll position and pagination state.
+ * Used for persisting and restoring the virtualizer state across navigation or page reloads.
+ *
+ * @typeParam TStartRow - The type of the start row data used for pagination anchoring
+ */
+export type ScrollHistoryState<
+  TStartRow,
+  TListContextParams = unknown,
+> = Readonly<{
+  /** The anchor point for pagination (includes position, direction, and start row data) */
+  anchor: Anchor<TStartRow>;
+  /** The scroll position in pixels from the top of the scrollable container */
+  scrollTop: number;
+  /** The estimated total number of rows in the list */
+  estimatedTotal: number;
+  /** Whether the virtualizer has reached the start of the list */
+  hasReachedStart: boolean;
+  /** Whether the virtualizer has reached the end of the list */
+  hasReachedEnd: boolean;
+  /** The list context params active when this state was saved (used to invalidate stale state) */
+  listContextParams: TListContextParams;
+}>;

--- a/src/core/virtualizer.test.ts
+++ b/src/core/virtualizer.test.ts
@@ -49,14 +49,27 @@ describe('ZeroVirtualizer snapshot — items, spacers and total', () => {
   test.for([
     {
       name: 'empty, loading (no rows yet)',
-      rows: {rowsLength: 0, complete: false, atStart: false, atEnd: false, firstRowIndex: 0},
+      rows: {
+        rowsLength: 0,
+        complete: false,
+        atStart: false,
+        atEnd: false,
+        firstRowIndex: 0,
+      },
       expectedItems: 0,
       expectedSpaceBefore: 0,
       expectedTotal: undefined,
     },
     {
       name: 'empty, complete',
-      rows: {rowsLength: 0, complete: true, rowsEmpty: true, atStart: true, atEnd: true, firstRowIndex: 0},
+      rows: {
+        rowsLength: 0,
+        complete: true,
+        rowsEmpty: true,
+        atStart: true,
+        atEnd: true,
+        firstRowIndex: 0,
+      },
       expectedItems: 0,
       expectedSpaceBefore: 0,
       expectedSpaceAfter: 0,
@@ -64,14 +77,28 @@ describe('ZeroVirtualizer snapshot — items, spacers and total', () => {
     },
     {
       name: 'loading from top, some rows',
-      rows: {rowsLength: 20, complete: false, rowsEmpty: false, atStart: true, atEnd: false, firstRowIndex: 0},
+      rows: {
+        rowsLength: 20,
+        complete: false,
+        rowsEmpty: false,
+        atStart: true,
+        atEnd: false,
+        firstRowIndex: 0,
+      },
       expectedItems: 20,
       expectedSpaceBefore: 0, // atStart
       expectedTotal: undefined,
     },
     {
       name: 'all rows loaded',
-      rows: {rowsLength: 20, complete: true, rowsEmpty: false, atStart: true, atEnd: true, firstRowIndex: 0},
+      rows: {
+        rowsLength: 20,
+        complete: true,
+        rowsEmpty: false,
+        atStart: true,
+        atEnd: true,
+        firstRowIndex: 0,
+      },
       expectedItems: 20,
       expectedSpaceBefore: 0,
       expectedSpaceAfter: 0,
@@ -79,7 +106,14 @@ describe('ZeroVirtualizer snapshot — items, spacers and total', () => {
     },
     {
       name: 'loading at end, rows above (firstRowIndex>0)',
-      rows: {rowsLength: 20, complete: false, rowsEmpty: false, atStart: false, atEnd: true, firstRowIndex: 5},
+      rows: {
+        rowsLength: 20,
+        complete: false,
+        rowsEmpty: false,
+        atStart: false,
+        atEnd: true,
+        firstRowIndex: 5,
+      },
       expectedItems: 20,
       expectedSpaceBefore: 5 * EST, // 5 estimated rows above
       expectedSpaceAfter: 0, // atEnd
@@ -87,14 +121,27 @@ describe('ZeroVirtualizer snapshot — items, spacers and total', () => {
     },
     {
       name: 'complete in middle (firstRowIndex>0)',
-      rows: {rowsLength: 50, complete: true, rowsEmpty: false, atStart: false, atEnd: false, firstRowIndex: 10},
+      rows: {
+        rowsLength: 50,
+        complete: true,
+        rowsEmpty: false,
+        atStart: false,
+        atEnd: false,
+        firstRowIndex: 10,
+      },
       expectedItems: 50,
       expectedSpaceBefore: 10 * EST,
       expectedTotal: undefined,
     },
   ])(
     '$name',
-    ({rows, expectedItems, expectedSpaceBefore, expectedSpaceAfter, expectedTotal}) => {
+    ({
+      rows,
+      expectedItems,
+      expectedSpaceBefore,
+      expectedSpaceAfter,
+      expectedTotal,
+    }) => {
       const snapshot = makeVirtualizer(rows).getSnapshot();
 
       expect(snapshot.items).toHaveLength(expectedItems);
@@ -127,7 +174,14 @@ describe('ZeroVirtualizer snapshot — items, spacers and total', () => {
 
   test('explicit count overrides estimated total', () => {
     const snapshot = makeVirtualizer(
-      {rowsLength: 20, complete: false, rowsEmpty: false, atStart: true, atEnd: false, firstRowIndex: 0},
+      {
+        rowsLength: 20,
+        complete: false,
+        rowsEmpty: false,
+        atStart: true,
+        atEnd: false,
+        firstRowIndex: 0,
+      },
       {count: 42},
     ).getSnapshot();
 
@@ -138,7 +192,14 @@ describe('ZeroVirtualizer snapshot — items, spacers and total', () => {
 
   test('explicit zero count reports empty list', () => {
     const snapshot = makeVirtualizer(
-      {rowsLength: 20, complete: false, rowsEmpty: false, atStart: true, atEnd: false, firstRowIndex: 0},
+      {
+        rowsLength: 20,
+        complete: false,
+        rowsEmpty: false,
+        atStart: true,
+        atEnd: false,
+        firstRowIndex: 0,
+      },
       {count: 0},
     ).getSnapshot();
 
@@ -150,10 +211,26 @@ describe('ZeroVirtualizer snapshot — items, spacers and total', () => {
 
 describe('ZeroVirtualizer wrapper contract', () => {
   test('snapshot identity is cached until state changes', () => {
-    const v = makeVirtualizer({rowsLength: 3, complete: true, rowsEmpty: false, atStart: true, atEnd: true, firstRowIndex: 0});
+    const v = makeVirtualizer({
+      rowsLength: 3,
+      complete: true,
+      rowsEmpty: false,
+      atStart: true,
+      atEnd: true,
+      firstRowIndex: 0,
+    });
     const a = v.getSnapshot();
     expect(v.getSnapshot()).toBe(a);
-    v.setRows(makeRows({rowsLength: 4, complete: true, rowsEmpty: false, atStart: true, atEnd: true, firstRowIndex: 0}));
+    v.setRows(
+      makeRows({
+        rowsLength: 4,
+        complete: true,
+        rowsEmpty: false,
+        atStart: true,
+        atEnd: true,
+        firstRowIndex: 0,
+      }),
+    );
     expect(v.getSnapshot()).not.toBe(a);
   });
 
@@ -164,7 +241,14 @@ describe('ZeroVirtualizer wrapper contract', () => {
 
     // Staging alone never notifies (render-safe).
     v.setRows(
-      makeRows({rowsLength: 10, complete: true, rowsEmpty: false, atStart: true, atEnd: false, firstRowIndex: 0}),
+      makeRows({
+        rowsLength: 10,
+        complete: true,
+        rowsEmpty: false,
+        atStart: true,
+        atEnd: false,
+        firstRowIndex: 0,
+      }),
     );
     v.setOptions(makeOptions());
     expect(listener).not.toHaveBeenCalled();

--- a/src/core/virtualizer.test.ts
+++ b/src/core/virtualizer.test.ts
@@ -1,0 +1,209 @@
+import {describe, expect, test, vi} from 'vitest';
+import type {RowsSnapshot} from './rows.ts';
+import {elementScrollAdapter} from './scroll-adapter.ts';
+import {ZeroVirtualizer, type VirtualizerOptions} from './virtualizer.ts';
+
+const EST = 48;
+
+function makeRows(
+  overrides: Partial<RowsSnapshot<unknown>>,
+): RowsSnapshot<unknown> {
+  return {
+    rowAt: () => undefined,
+    rowsLength: 0,
+    complete: false,
+    rowsEmpty: true,
+    atStart: false,
+    atEnd: false,
+    firstRowIndex: 0,
+    permalinkNotFound: false,
+    ...overrides,
+  };
+}
+
+function makeOptions(
+  overrides: Partial<VirtualizerOptions<unknown, unknown, unknown>> = {},
+): VirtualizerOptions<unknown, unknown, unknown> {
+  return {
+    estimateSize: () => EST,
+    getRowKey: row => (row as {id: string}).id,
+    listContextParams: {},
+    ...overrides,
+  };
+}
+
+function makeVirtualizer(
+  rows: Partial<RowsSnapshot<unknown>>,
+  options: Partial<VirtualizerOptions<unknown, unknown, unknown>> = {},
+) {
+  const v = new ZeroVirtualizer(makeOptions(options), elementScrollAdapter);
+  v.setRows(makeRows(rows));
+  return v;
+}
+
+// Rows are rendered in flow between a top spacer (`spaceBefore`) and a bottom
+// spacer (`spaceAfter`); there is no virtual "count". These cases pin down the
+// derived outputs — the same table the React hook test used, now exercised
+// directly against the framework-free core (which also covers Solid).
+describe('ZeroVirtualizer snapshot — items, spacers and total', () => {
+  test.for([
+    {
+      name: 'empty, loading (no rows yet)',
+      rows: {rowsLength: 0, complete: false, atStart: false, atEnd: false, firstRowIndex: 0},
+      expectedItems: 0,
+      expectedSpaceBefore: 0,
+      expectedTotal: undefined,
+    },
+    {
+      name: 'empty, complete',
+      rows: {rowsLength: 0, complete: true, rowsEmpty: true, atStart: true, atEnd: true, firstRowIndex: 0},
+      expectedItems: 0,
+      expectedSpaceBefore: 0,
+      expectedSpaceAfter: 0,
+      expectedTotal: 0,
+    },
+    {
+      name: 'loading from top, some rows',
+      rows: {rowsLength: 20, complete: false, rowsEmpty: false, atStart: true, atEnd: false, firstRowIndex: 0},
+      expectedItems: 20,
+      expectedSpaceBefore: 0, // atStart
+      expectedTotal: undefined,
+    },
+    {
+      name: 'all rows loaded',
+      rows: {rowsLength: 20, complete: true, rowsEmpty: false, atStart: true, atEnd: true, firstRowIndex: 0},
+      expectedItems: 20,
+      expectedSpaceBefore: 0,
+      expectedSpaceAfter: 0,
+      expectedTotal: 20,
+    },
+    {
+      name: 'loading at end, rows above (firstRowIndex>0)',
+      rows: {rowsLength: 20, complete: false, rowsEmpty: false, atStart: false, atEnd: true, firstRowIndex: 5},
+      expectedItems: 20,
+      expectedSpaceBefore: 5 * EST, // 5 estimated rows above
+      expectedSpaceAfter: 0, // atEnd
+      expectedTotal: undefined,
+    },
+    {
+      name: 'complete in middle (firstRowIndex>0)',
+      rows: {rowsLength: 50, complete: true, rowsEmpty: false, atStart: false, atEnd: false, firstRowIndex: 10},
+      expectedItems: 50,
+      expectedSpaceBefore: 10 * EST,
+      expectedTotal: undefined,
+    },
+  ])(
+    '$name',
+    ({rows, expectedItems, expectedSpaceBefore, expectedSpaceAfter, expectedTotal}) => {
+      const snapshot = makeVirtualizer(rows).getSnapshot();
+
+      expect(snapshot.items).toHaveLength(expectedItems);
+      expect(snapshot.total).toBe(expectedTotal);
+      if (expectedSpaceBefore !== undefined) {
+        expect(snapshot.spaceBefore).toBe(expectedSpaceBefore);
+      }
+      if (expectedSpaceAfter !== undefined) {
+        expect(snapshot.spaceAfter).toBe(expectedSpaceAfter);
+      }
+    },
+  );
+
+  test('items carry the correct index and row', () => {
+    const rowsData = [{id: 'a'}, {id: 'b'}, {id: 'c'}];
+    const snapshot = makeVirtualizer({
+      rowsLength: 3,
+      complete: true,
+      rowsEmpty: false,
+      atStart: false,
+      atEnd: false,
+      firstRowIndex: 7,
+      rowAt: (i: number) => rowsData[i - 7],
+    }).getSnapshot();
+
+    expect(snapshot.items.map(it => it.index)).toEqual([7, 8, 9]);
+    expect(snapshot.items.map(it => it.key)).toEqual(['a', 'b', 'c']);
+    expect(snapshot.items[0].row).toEqual({id: 'a'});
+  });
+
+  test('explicit count overrides estimated total', () => {
+    const snapshot = makeVirtualizer(
+      {rowsLength: 20, complete: false, rowsEmpty: false, atStart: true, atEnd: false, firstRowIndex: 0},
+      {count: 42},
+    ).getSnapshot();
+
+    expect(snapshot.estimatedTotal).toBe(42);
+    expect(snapshot.total).toBe(42);
+    expect(snapshot.rowsEmpty).toBe(false);
+  });
+
+  test('explicit zero count reports empty list', () => {
+    const snapshot = makeVirtualizer(
+      {rowsLength: 20, complete: false, rowsEmpty: false, atStart: true, atEnd: false, firstRowIndex: 0},
+      {count: 0},
+    ).getSnapshot();
+
+    expect(snapshot.estimatedTotal).toBe(0);
+    expect(snapshot.total).toBe(0);
+    expect(snapshot.rowsEmpty).toBe(true);
+  });
+});
+
+describe('ZeroVirtualizer wrapper contract', () => {
+  test('snapshot identity is cached until state changes', () => {
+    const v = makeVirtualizer({rowsLength: 3, complete: true, rowsEmpty: false, atStart: true, atEnd: true, firstRowIndex: 0});
+    const a = v.getSnapshot();
+    expect(v.getSnapshot()).toBe(a);
+    v.setRows(makeRows({rowsLength: 4, complete: true, rowsEmpty: false, atStart: true, atEnd: true, firstRowIndex: 0}));
+    expect(v.getSnapshot()).not.toBe(a);
+  });
+
+  test('setRows/setOptions are silent; afterDOMUpdate notifies on transitions', () => {
+    const v = new ZeroVirtualizer(makeOptions(), elementScrollAdapter);
+    const listener = vi.fn();
+    v.subscribe(listener);
+
+    // Staging alone never notifies (render-safe).
+    v.setRows(
+      makeRows({rowsLength: 10, complete: true, rowsEmpty: false, atStart: true, atEnd: false, firstRowIndex: 0}),
+    );
+    v.setOptions(makeOptions());
+    expect(listener).not.toHaveBeenCalled();
+
+    // afterDOMUpdate applies the reached-start latch + estimate bump → notify.
+    v.afterDOMUpdate();
+    expect(listener).toHaveBeenCalled();
+    expect(v.getQueryInputs().anchor).toEqual({
+      index: 0,
+      kind: 'forward',
+      startRow: undefined,
+    });
+  });
+
+  test('query inputs fall back to the new context after a context change', () => {
+    const ctxA = {sort: 'a'};
+    const v = new ZeroVirtualizer(
+      makeOptions({listContextParams: ctxA}),
+      elementScrollAdapter,
+    );
+    expect(v.getQueryInputs().anchor.kind).toBe('forward');
+
+    // New context: queries must immediately target it (top anchor), even
+    // before afterDOMUpdate commits the reset.
+    v.setOptions(makeOptions({listContextParams: {sort: 'b'}}));
+    expect(v.getQueryInputs().anchor).toEqual({
+      index: 0,
+      kind: 'forward',
+      startRow: undefined,
+    });
+
+    // A permalink wins as the fallback anchor.
+    v.setOptions(
+      makeOptions({listContextParams: {sort: 'c'}, permalinkID: 'row-9'}),
+    );
+    expect(v.getQueryInputs().anchor).toEqual({
+      index: 1,
+      kind: 'permalink',
+      id: 'row-9',
+    });
+  });
+});

--- a/src/core/virtualizer.ts
+++ b/src/core/virtualizer.ts
@@ -22,13 +22,6 @@ const MIN_PAGE_SIZE = 100;
 
 const NUM_ROWS_FOR_LOADING_SKELETON = 1;
 
-// After the finger lifts, assume momentum may still be gliding for at least this
-// long before an idle-timeout is allowed to conclude the gesture has ended.
-const MOMENTUM_GUARD_MS = 180;
-// How long the scroll must be quiet (no scroll events) before we treat a gesture
-// as ended, when the native `scrollend` event isn't available. Tune on device.
-const IDLE_DEBOUNCE_MS = 120;
-
 // Debounce for persisting scroll state via onScrollStateChange.
 const PERSIST_DEBOUNCE_MS = 100;
 
@@ -226,8 +219,10 @@ export class ZeroVirtualizer<TListContextParams, TRow, TStartRow> {
   // scrolls can safely write scrollTop.
   #touchScroll = false;
   #fingerDown = false;
-  #momentumGuardUntil = 0;
-  #idleTimer: ReturnType<typeof setTimeout> | undefined;
+  // Whether any (non-programmatic) scrolling happened during the current touch
+  // gesture: a plain tap must end the gesture at touchend itself, because no
+  // scrolling means no `scrollend` will ever fire for it.
+  #gestureScrolled = false;
   #settleTimer: ReturnType<typeof setTimeout> | undefined;
   #persistTimer: ReturnType<typeof setTimeout> | undefined;
   // The live anchoring state; also exposed (read-only) as `debug`.
@@ -377,7 +372,6 @@ export class ZeroVirtualizer<TListContextParams, TRow, TStartRow> {
     this.#resizeObserver?.disconnect();
     this.#resizeObserver = null;
     this.#observedItems = null;
-    clearTimeout(this.#idleTimer);
     clearTimeout(this.#settleTimer);
     clearTimeout(this.#persistTimer);
     this.#adapter.scrollElement(el).style.overflowAnchor =
@@ -765,7 +759,6 @@ export class ZeroVirtualizer<TListContextParams, TRow, TStartRow> {
     this.#anchorState.isScrolling = false;
     this.#touchScroll = false;
     this.#fingerDown = false;
-    clearTimeout(this.#idleTimer);
     this.#flushHold();
     this.#refreshAnchor();
     this.#evaluate();
@@ -785,21 +778,10 @@ export class ZeroVirtualizer<TListContextParams, TRow, TStartRow> {
   }
 
   // ---- event handlers --------------------------------------------------------
-
-  #scheduleIdleCheck(): void {
-    clearTimeout(this.#idleTimer);
-    this.#idleTimer = setTimeout(() => this.#tryEndScroll(), IDLE_DEBOUNCE_MS);
-  }
-
-  #tryEndScroll(): void {
-    // Never end while a finger is down or momentum may still be gliding — a
-    // scrollTop write then would cancel the fling (the classic iOS jolt).
-    if (this.#fingerDown || Date.now() < this.#momentumGuardUntil) {
-      this.#scheduleIdleCheck();
-      return;
-    }
-    this.#withNotify(() => this.#endScrolling());
-  }
+  // Gesture end is driven by the native `scrollend` event (guaranteed by the
+  // supported browsers — see the Safari 26 requirement in the README), plus
+  // touch state: a gesture never ends while a finger is down, and a tap that
+  // never scrolled ends at touchend (no scrolling → no scrollend).
 
   #onScroll = (): void => {
     const programmatic = this.#programmaticScroll;
@@ -811,8 +793,8 @@ export class ZeroVirtualizer<TListContextParams, TRow, TStartRow> {
     // anchor.
     if (this.#manual() && !programmatic) {
       this.#anchorState.isScrolling = true;
+      this.#gestureScrolled = true;
       this.#refreshAnchor();
-      if (!this.#fingerDown) this.#scheduleIdleCheck();
     }
     this.#resetSettleTimer();
     this.#withNotify(() => this.#evaluate());
@@ -828,14 +810,21 @@ export class ZeroVirtualizer<TListContextParams, TRow, TStartRow> {
   #onTouchStart = (): void => {
     this.#fingerDown = true;
     this.#touchScroll = true;
+    // Arm the hold path immediately so a correction landing between
+    // touchstart and the first scroll event never writes scrollTop under an
+    // active finger.
     this.#anchorState.isScrolling = true;
-    clearTimeout(this.#idleTimer);
+    this.#gestureScrolled = false;
   };
 
   #onTouchEnd = (): void => {
     this.#fingerDown = false;
-    this.#momentumGuardUntil = Date.now() + MOMENTUM_GUARD_MS;
-    this.#scheduleIdleCheck();
+    if (!this.#gestureScrolled) {
+      // A tap: nothing scrolled, so no scrollend is coming — end now.
+      this.#withNotify(() => this.#endScrolling());
+    }
+    // Otherwise momentum (or the just-finished drag) concludes with the
+    // browser's scrollend, which reconciles via #onScrollEnd.
   };
 
   // Scroll-driven evaluation (replaces the old scrollTick re-render): paging,

--- a/src/core/virtualizer.ts
+++ b/src/core/virtualizer.ts
@@ -392,8 +392,10 @@ export class ZeroVirtualizer<TListContextParams, TRow, TStartRow> {
    * observable changed.
    */
   afterDOMUpdate(): void {
-    const startVersion = this.#version;
+    this.#withNotify(() => this.#afterDOMUpdate());
+  }
 
+  #afterDOMUpdate(): void {
     // The settle clock restarts when the list context changes (new sort /
     // filter = a fresh, un-settled list).
     if (this.#options.listContextParams !== this.#lastSettleContext) {
@@ -415,10 +417,6 @@ export class ZeroVirtualizer<TListContextParams, TRow, TStartRow> {
     this.#relabelAnchor();
     this.#evaluatePaging();
     this.#schedulePersistIfChanged();
-
-    if (this.#version !== startVersion) {
-      this.#notify();
-    }
   }
 
   // ---- derived values --------------------------------------------------------
@@ -574,6 +572,16 @@ export class ZeroVirtualizer<TListContextParams, TRow, TStartRow> {
   #notify(): void {
     for (const listener of this.#listeners) {
       listener();
+    }
+  }
+
+  // Run a state-mutating block outside render, notifying listeners once at
+  // the end if anything observable changed.
+  #withNotify(fn: () => void): void {
+    const before = this.#version;
+    fn();
+    if (this.#version !== before) {
+      this.#notify();
     }
   }
 
@@ -790,9 +798,7 @@ export class ZeroVirtualizer<TListContextParams, TRow, TStartRow> {
       this.#scheduleIdleCheck();
       return;
     }
-    const before = this.#version;
-    this.#endScrolling();
-    if (this.#version !== before) this.#notify();
+    this.#withNotify(() => this.#endScrolling());
   }
 
   #onScroll = (): void => {
@@ -809,17 +815,13 @@ export class ZeroVirtualizer<TListContextParams, TRow, TStartRow> {
       if (!this.#fingerDown) this.#scheduleIdleCheck();
     }
     this.#resetSettleTimer();
-    const before = this.#version;
-    this.#evaluate();
-    if (this.#version !== before) this.#notify();
+    this.#withNotify(() => this.#evaluate());
   };
 
   #onScrollEnd = (): void => {
     if (!this.#manual()) return;
     if (!this.#fingerDown) {
-      const before = this.#version;
-      this.#endScrolling();
-      if (this.#version !== before) this.#notify();
+      this.#withNotify(() => this.#endScrolling());
     }
   };
 
@@ -1050,11 +1052,9 @@ export class ZeroVirtualizer<TListContextParams, TRow, TStartRow> {
     if (items === this.#observedItems && this.#resizeObserver) return;
     this.#observedItems = items;
     this.#resizeObserver?.disconnect();
-    this.#resizeObserver = new ResizeObserver(() => {
-      const before = this.#version;
-      this.#measureAndCompensate();
-      if (this.#version !== before) this.#notify();
-    });
+    this.#resizeObserver = new ResizeObserver(() =>
+      this.#withNotify(() => this.#measureAndCompensate()),
+    );
     for (const child of queryRows(el)) {
       this.#resizeObserver.observe(child, {box: 'border-box'});
     }

--- a/src/core/virtualizer.ts
+++ b/src/core/virtualizer.ts
@@ -974,7 +974,10 @@ export class ZeroVirtualizer<TListContextParams, TRow, TStartRow> {
         estimatedTotal: 0,
         hasReachedStart: true,
         hasReachedEnd: false,
-        queryAnchor: {anchor: TOP_ANCHOR as Anchor<TStartRow>, listContextParams},
+        queryAnchor: {
+          anchor: TOP_ANCHOR as Anchor<TStartRow>,
+          listContextParams,
+        },
       });
     }
   }

--- a/src/core/virtualizer.ts
+++ b/src/core/virtualizer.ts
@@ -1,0 +1,1237 @@
+import {assert} from '../asserts.ts';
+import {
+  findRow,
+  firstRow,
+  queryRows,
+  rectInViewport,
+  VROW_INDEX_ATTR,
+  VROW_KEY_ATTR,
+} from './dom.ts';
+import type {RowsQueryInputs, RowsSnapshot} from './rows.ts';
+import type {ScrollAdapter, ScrollRect} from './scroll-adapter.ts';
+import type {
+  Anchor,
+  AnchoringMode,
+  RowKey,
+  ScrollHistoryState,
+  VirtualRow,
+} from './types.ts';
+
+// Make sure this is even since we half it for scroll state loading
+const MIN_PAGE_SIZE = 100;
+
+const NUM_ROWS_FOR_LOADING_SKELETON = 1;
+
+// After the finger lifts, assume momentum may still be gliding for at least this
+// long before an idle-timeout is allowed to conclude the gesture has ended.
+const MOMENTUM_GUARD_MS = 180;
+// How long the scroll must be quiet (no scroll events) before we treat a gesture
+// as ended, when the native `scrollend` event isn't available. Tune on device.
+const IDLE_DEBOUNCE_MS = 120;
+
+// Debounce for persisting scroll state via onScrollStateChange.
+const PERSIST_DEBOUNCE_MS = 100;
+
+const defaultKeyExtractor = (index: number): RowKey => index;
+
+// Use manual anchoring wherever the browser doesn't implement CSS scroll
+// anchoring - notably older versions of Safari. Feature detection, not UA
+// sniffing; overridable via the `anchoring` option.
+function detectNeedsManualAnchoring(): boolean {
+  return typeof CSS === 'undefined' || !CSS.supports('overflow-anchor', 'auto');
+}
+
+const TOP_ANCHOR = Object.freeze({
+  index: 0,
+  kind: 'forward',
+  startRow: undefined,
+}) satisfies Anchor<unknown>;
+
+const createPermalinkAnchor = (id: string) =>
+  ({
+    id,
+    index: NUM_ROWS_FOR_LOADING_SKELETON,
+    kind: 'permalink',
+  }) as const;
+
+/**
+ * Pairs the paging anchor with the list-context params (sort/filter) it was
+ * created under, so the two can only change together. While they disagree with
+ * the current options (`!isListContextCurrent` — e.g. right after a sort change
+ * or browser back/forward), paging and count updates stand down: we never
+ * query with an anchor from one context against the params of another.
+ */
+type QueryAnchor<TListContextParams, TStartRow> = {
+  readonly anchor: Anchor<TStartRow>;
+  readonly listContextParams: TListContextParams;
+};
+
+/**
+ * The virtualizer's pagination state. Kept in a single object so multi-field
+ * updates — e.g. relabeling the anchor index together with the estimated total
+ * — stay atomic.
+ */
+type PagingState<TListContextParams, TStartRow> = {
+  estimatedTotal: number;
+  hasReachedStart: boolean;
+  hasReachedEnd: boolean;
+  queryAnchor: QueryAnchor<TListContextParams, TStartRow>;
+};
+
+function restoredPagingState<TListContextParams, TStartRow>(
+  state: ScrollHistoryState<TStartRow>,
+  listContextParams: TListContextParams,
+): PagingState<TListContextParams, TStartRow> {
+  return {
+    estimatedTotal: state.estimatedTotal,
+    hasReachedStart: state.hasReachedStart,
+    hasReachedEnd: state.hasReachedEnd,
+    queryAnchor: {anchor: state.anchor, listContextParams},
+  };
+}
+
+function permalinkPagingState<TListContextParams, TStartRow>(
+  id: string,
+  listContextParams: TListContextParams,
+): PagingState<TListContextParams, TStartRow> {
+  return {
+    estimatedTotal: NUM_ROWS_FOR_LOADING_SKELETON,
+    hasReachedStart: false,
+    hasReachedEnd: false,
+    queryAnchor: {anchor: createPermalinkAnchor(id), listContextParams},
+  };
+}
+
+/**
+ * Framework-free options of {@linkcode ZeroVirtualizer}. The framework
+ * wrappers add their own fields on top (`getScrollElement`, the query
+ * functions, `scrollAdapter`) — those never reach the core: elements arrive
+ * via {@linkcode ZeroVirtualizer.attach} and query results via
+ * {@linkcode ZeroVirtualizer.setRows}.
+ */
+export type VirtualizerOptions<TListContextParams, TRow, TStartRow> = {
+  estimateSize: (index: number) => number;
+  overscan?: number | undefined;
+  anchoring?: AnchoringMode | undefined;
+  getRowKey: (row: TRow) => RowKey;
+  listContextParams: TListContextParams;
+  count?: number | undefined;
+  permalinkID?: string | null | undefined;
+  settleTime?: number | undefined;
+  scrollState?: ScrollHistoryState<TStartRow> | null | undefined;
+  onScrollStateChange?:
+    | ((state: ScrollHistoryState<TStartRow>) => void)
+    | undefined;
+  onSettled?: (() => void) | undefined;
+};
+
+/** What {@linkcode ZeroVirtualizer.getSnapshot} returns — see the react hook's
+ * result docs for field semantics. Cached: identity changes only when content
+ * actually changed. */
+export type VirtualizerSnapshot<TRow> = {
+  items: ReadonlyArray<VirtualRow<TRow>>;
+  spaceBefore: number;
+  spaceAfter: number;
+  rowAt: (index: number) => TRow | undefined;
+  complete: boolean;
+  rowsEmpty: boolean;
+  permalinkNotFound: boolean;
+  estimatedTotal: number;
+  total: number | undefined;
+  settled: boolean;
+  debug: {
+    readonly current: {
+      readonly isScrolling: boolean;
+      readonly pendingJump: number;
+    };
+  };
+};
+
+const EMPTY_ROWS: RowsSnapshot<unknown> = {
+  rowAt: () => undefined,
+  rowsLength: 0,
+  complete: false,
+  rowsEmpty: true,
+  atStart: false,
+  atEnd: false,
+  firstRowIndex: 0,
+  permalinkNotFound: false,
+};
+
+/**
+ * The framework-agnostic virtualizer: bidirectional paging over Zero queries
+ * with scroll anchoring (native `overflow-anchor` where supported, a
+ * momentum-safe manual equivalent elsewhere).
+ *
+ * Lifecycle contract with framework wrappers (TanStack-Virtual-style):
+ * - Construct once per component lifetime (the constructor is pure — no DOM,
+ *   listeners, or timers — so speculative construction is safe).
+ * - `setOptions()` on every render/reactive update and `setRows()` whenever
+ *   query results change. Both are silent data ingestion: they never notify
+ *   and never touch the DOM (they may be called mid-render).
+ * - `attach()` + `afterDOMUpdate()` after the framework committed row DOM,
+ *   before paint (React: layout effect; Solid: effect). All state transitions
+ *   and DOM work flush here or from scroll/touch/timer events.
+ * - Rendering state comes from `getSnapshot()` (cached identity); re-render
+ *   signals from `subscribe()`.
+ *
+ * @experimental The core API is public but unstable; the `./react` and
+ * `./solid` entry points are the stable surfaces.
+ */
+export class ZeroVirtualizer<TListContextParams, TRow, TStartRow> {
+  readonly #adapter: ScrollAdapter;
+  #options: VirtualizerOptions<TListContextParams, TRow, TStartRow>;
+  #rows: RowsSnapshot<TRow> = EMPTY_ROWS as RowsSnapshot<TRow>;
+
+  // ---- paging state ---------------------------------------------------------
+  #paging: PagingState<TListContextParams, TStartRow>;
+  #pageSize = MIN_PAGE_SIZE;
+  #settled = false;
+
+  // ---- change propagation ---------------------------------------------------
+  readonly #listeners = new Set<() => void>();
+  // Bumped by every mutation that can affect the snapshot or query inputs.
+  #version = 0;
+  // Version at the last snapshot build (cache key).
+  #snapshotVersion = -1;
+  #snapshot: VirtualizerSnapshot<TRow> | null = null;
+  #itemsCache: {
+    key: readonly [
+      (index: number) => TRow | undefined,
+      number,
+      number,
+      (row: TRow) => RowKey,
+    ];
+    items: VirtualRow<TRow>[];
+  } | null = null;
+
+  // ---- scroll / anchoring machine (all imperative) --------------------------
+  #el: HTMLElement | null = null;
+  #unsubscribe: (() => void) | null = null;
+  #prevOverflowAnchor = '';
+  #detachTouch: (() => void) | null = null;
+  #resizeObserver: ResizeObserver | null = null;
+  #observedItems: ReadonlyArray<VirtualRow<TRow>> | null = null;
+  #programmaticScroll = false;
+  #anchorKey: RowKey | null = null;
+  // The reference row's top offset from the viewport top, in the settled
+  // (hold-free) frame — what the anchoring keeps stable across relabels and
+  // off-screen resizes (matching native `overflow-anchor`).
+  #anchorOffset = 0;
+  // True from a list reset (context change / restore / permalink) until the new
+  // data has loaded, so we don't adopt or pin a stale reference row.
+  #anchorSuppressed = false;
+  // Whether the in-flight scroll was initiated by touch. Only then do we take
+  // the momentum-safe margin-hold path — wheel / trackpad / programmatic
+  // scrolls can safely write scrollTop.
+  #touchScroll = false;
+  #fingerDown = false;
+  #momentumGuardUntil = 0;
+  #idleTimer: ReturnType<typeof setTimeout> | undefined;
+  #settleTimer: ReturnType<typeof setTimeout> | undefined;
+  #persistTimer: ReturnType<typeof setTimeout> | undefined;
+  // The live anchoring state; also exposed (read-only) as `debug`.
+  readonly #anchorState = {isScrolling: false, pendingJump: 0};
+  // The row element currently carrying the held margin.
+  #holdEl: HTMLElement | null = null;
+
+  // Set to a permalink id when navigation targets a row that is NOT currently
+  // visible, meaning we should scroll it to the top once it loads. Stays null
+  // when a permalink points at an already-visible row (clicking a row never
+  // scrolls it).
+  #pendingPermalinkScroll: RowKey | null;
+
+  // Restore/reset change tracking (the old effect's dependency semantics).
+  #appliedScrollState: ScrollHistoryState<TStartRow> | null = null;
+  #appliedPermalinkID: string | null | undefined;
+  // effectiveScrollState cache, keyed by the identities of its two inputs.
+  #effScrollStateKey: readonly [unknown, unknown] | null = null;
+  #effScrollState: ScrollHistoryState<TStartRow> | null = null;
+  // Persist-scheduling change detection.
+  #lastPersistKey = '';
+  // Settle-timer reset on list-context change (the old effect's dep).
+  #lastSettleContext: TListContextParams;
+
+  constructor(
+    options: VirtualizerOptions<TListContextParams, TRow, TStartRow>,
+    adapter: ScrollAdapter,
+  ) {
+    this.#adapter = adapter;
+    this.#options = options;
+    // Initialize paging directly from the restorable state so the first
+    // render already queries the right window (this also survives React
+    // Strict Mode's double construction — the constructor is pure).
+    const eff = this.#effectiveScrollState();
+    const {permalinkID, listContextParams} = options;
+    this.#paging = eff
+      ? restoredPagingState(eff, listContextParams)
+      : permalinkID
+        ? permalinkPagingState(permalinkID, listContextParams)
+        : {
+            estimatedTotal: NUM_ROWS_FOR_LOADING_SKELETON,
+            hasReachedStart: false,
+            hasReachedEnd: false,
+            queryAnchor: {anchor: TOP_ANCHOR, listContextParams},
+          };
+    this.#pendingPermalinkScroll = permalinkID && !eff ? permalinkID : null;
+    this.#appliedPermalinkID = permalinkID;
+    this.#lastSettleContext = listContextParams;
+  }
+
+  // ---- wrapper-facing surface ------------------------------------------------
+
+  /** Silent options ingestion — safe to call during render. */
+  setOptions(
+    options: VirtualizerOptions<TListContextParams, TRow, TStartRow>,
+  ): void {
+    this.#options = options;
+  }
+
+  /** Silent rows ingestion — safe to call during render. */
+  setRows(rows: RowsSnapshot<TRow>): void {
+    if (rows !== this.#rows) {
+      this.#rows = rows;
+      this.#version++;
+    }
+  }
+
+  /**
+   * The inputs the framework wrapper must feed into its Zero query binding
+   * (results come back via {@linkcode setRows}).
+   */
+  getQueryInputs(): RowsQueryInputs<TStartRow> {
+    return {
+      pageSize: this.#pageSize,
+      anchor: this.#effectiveAnchor(),
+      settled: this.#settled,
+    };
+  }
+
+  /** Re-render signal for wrappers; returns an unsubscribe fn. */
+  subscribe(listener: () => void): () => void {
+    this.#listeners.add(listener);
+    return () => this.#listeners.delete(listener);
+  }
+
+  /** The current render state. Cached — identity changes only with content. */
+  getSnapshot(): VirtualizerSnapshot<TRow> {
+    if (this.#snapshot !== null && this.#snapshotVersion === this.#version) {
+      return this.#snapshot;
+    }
+    this.#snapshot = this.#buildSnapshot();
+    this.#snapshotVersion = this.#version;
+    return this.#snapshot;
+  }
+
+  /**
+   * Wire (or re-wire, if the element changed) the scroll container. Idempotent
+   * per element; call every commit alongside {@linkcode afterDOMUpdate}.
+   */
+  attach(el: HTMLElement | null): void {
+    if (el === this.#el) return;
+    this.#detachEl();
+    this.#el = el;
+    if (!el) return;
+
+    // Toggle native scroll anchoring to match the resolved mode: off (so it
+    // can't fight our compensation) in manual mode, on in native mode. Set on
+    // the scroll element; spacers keep their own `overflow-anchor: none` so
+    // native mode still anchors to a real row, not a resizing spacer.
+    const scroller = this.#adapter.scrollElement(el);
+    this.#prevOverflowAnchor = scroller.style.overflowAnchor;
+    scroller.style.overflowAnchor = this.#manual() ? 'none' : 'auto';
+
+    this.#unsubscribe = this.#adapter.subscribe(
+      el,
+      this.#onScroll,
+      this.#onScrollEnd,
+    );
+    // Touch events bubble, so the scroll element hears every touch inside it.
+    // The touch/scrollend machinery only drives manual mode.
+    if (this.#manual()) {
+      const t = scroller;
+      t.addEventListener('touchstart', this.#onTouchStart, {passive: true});
+      t.addEventListener('touchend', this.#onTouchEnd, {passive: true});
+      t.addEventListener('touchcancel', this.#onTouchEnd, {passive: true});
+      this.#detachTouch = () => {
+        t.removeEventListener('touchstart', this.#onTouchStart);
+        t.removeEventListener('touchend', this.#onTouchEnd);
+        t.removeEventListener('touchcancel', this.#onTouchEnd);
+      };
+    }
+    this.#resetSettleTimer();
+  }
+
+  /** Remove all listeners/observers/timers. State survives (Strict Mode). */
+  detach(): void {
+    this.#detachEl();
+  }
+
+  #detachEl(): void {
+    const el = this.#el;
+    if (!el) return;
+    this.#unsubscribe?.();
+    this.#unsubscribe = null;
+    this.#detachTouch?.();
+    this.#detachTouch = null;
+    this.#resizeObserver?.disconnect();
+    this.#resizeObserver = null;
+    this.#observedItems = null;
+    clearTimeout(this.#idleTimer);
+    clearTimeout(this.#settleTimer);
+    clearTimeout(this.#persistTimer);
+    this.#adapter.scrollElement(el).style.overflowAnchor =
+      this.#prevOverflowAnchor;
+    this.#el = null;
+  }
+
+  /**
+   * Run after the framework committed row DOM, before paint. Hosts every
+   * rows/options-driven state transition and all layout-reading DOM work (the
+   * old React effect chain, in commit order). Notifies at the end if anything
+   * observable changed.
+   */
+  afterDOMUpdate(): void {
+    const startVersion = this.#version;
+
+    // The settle clock restarts when the list context changes (new sort /
+    // filter = a fresh, un-settled list).
+    if (this.#options.listContextParams !== this.#lastSettleContext) {
+      this.#lastSettleContext = this.#options.listContextParams;
+      this.#resetSettleTimer();
+    }
+
+    // -- layout-effect phase (order preserved from the React hook) --
+    this.#measureAndCompensate();
+    this.#reobserveRows();
+    this.#restoreOrReset();
+    this.#retryPendingPermalinkScroll();
+
+    // -- passive-effect phase --
+    this.#liftAnchorSuppression();
+    this.#updatePageSize();
+    this.#applyReachedLatches();
+    this.#bumpEstimatedTotal();
+    this.#relabelAnchor();
+    this.#evaluatePaging();
+    this.#schedulePersistIfChanged();
+
+    if (this.#version !== startVersion) {
+      this.#notify();
+    }
+  }
+
+  // ---- derived values --------------------------------------------------------
+
+  #manual(): boolean {
+    const anchoring = this.#options.anchoring ?? 'auto';
+    return (
+      anchoring === 'manual' ||
+      (anchoring === 'auto' && detectNeedsManualAnchoring())
+    );
+  }
+
+  // Only restore from scrollState if its listContextParams matches the current
+  // context. JSON compare (state may come from serialized storage where object
+  // identity is not preserved), cached by input identities so it isn't
+  // re-stringified per call.
+  #effectiveScrollState(): ScrollHistoryState<TStartRow> | null {
+    const {scrollState, listContextParams} = this.#options;
+    const key = [scrollState, listContextParams] as const;
+    if (
+      this.#effScrollStateKey &&
+      this.#effScrollStateKey[0] === key[0] &&
+      this.#effScrollStateKey[1] === key[1]
+    ) {
+      return this.#effScrollState;
+    }
+    let eff: ScrollHistoryState<TStartRow> | null = null;
+    if (scrollState) {
+      eff =
+        JSON.stringify(scrollState.listContextParams) ===
+        JSON.stringify(listContextParams)
+          ? scrollState
+          : null;
+    }
+    this.#effScrollStateKey = key;
+    this.#effScrollState = eff;
+    return eff;
+  }
+
+  #isListContextCurrent(): boolean {
+    return (
+      this.#paging.queryAnchor.listContextParams ===
+      this.#options.listContextParams
+    );
+  }
+
+  // The anchor the queries should use *right now*: the paging anchor while it
+  // belongs to the current context; otherwise (first render after a context
+  // change) fall back so the very first query already targets the new context.
+  #effectiveAnchor(): Anchor<TStartRow> {
+    if (this.#isListContextCurrent()) {
+      return this.#paging.queryAnchor.anchor;
+    }
+    const {permalinkID} = this.#options;
+    return permalinkID
+      ? createPermalinkAnchor(permalinkID)
+      : (TOP_ANCHOR as Anchor<TStartRow>);
+  }
+
+  #rowEstimate(): number {
+    return Math.max(1, this.#options.estimateSize(0));
+  }
+
+  #effectiveEstimatedTotal(): number {
+    const {count} = this.#options;
+    const rows = this.#rows;
+    const newEstimatedTotal = rows.firstRowIndex + rows.rowsLength;
+    return (
+      count ??
+      (rows.atEnd && rows.atStart && rows.complete
+        ? rows.rowsLength
+        : Math.max(this.#paging.estimatedTotal, newEstimatedTotal))
+    );
+  }
+
+  #buildSnapshot(): VirtualizerSnapshot<TRow> {
+    const rows = this.#rows;
+    const {count, getRowKey} = this.#options;
+    const {estimatedTotal, hasReachedStart, hasReachedEnd} = this.#paging;
+    const effectiveEstimatedTotal = this.#effectiveEstimatedTotal();
+
+    // Spacer heights: the estimated pixel extent of the unloaded rows above
+    // and below the loaded window (the scrollbar is approximate, exactly as
+    // with any virtualized list).
+    const rowEstimate = this.#rowEstimate();
+    const rowsBefore = Math.max(0, rows.firstRowIndex);
+    const rowsAfter = rows.atEnd
+      ? 0
+      : Math.max(
+          0,
+          effectiveEstimatedTotal - (rows.firstRowIndex + rows.rowsLength),
+        );
+
+    // The rows to render, keyed by row id when loaded so their DOM nodes
+    // persist across paging — that identity is what scroll anchoring measures
+    // against. Cached so items identity is stable when the window is.
+    const itemsKey = [
+      rows.rowAt,
+      rows.firstRowIndex,
+      rows.rowsLength,
+      getRowKey,
+    ] as const;
+    let items: VirtualRow<TRow>[];
+    const cached = this.#itemsCache;
+    if (
+      cached &&
+      cached.key[0] === itemsKey[0] &&
+      cached.key[1] === itemsKey[1] &&
+      cached.key[2] === itemsKey[2] &&
+      cached.key[3] === itemsKey[3]
+    ) {
+      items = cached.items;
+    } else {
+      items = [];
+      for (
+        let i = rows.firstRowIndex;
+        i < rows.firstRowIndex + rows.rowsLength;
+        i++
+      ) {
+        const row = rows.rowAt(i);
+        items.push({
+          index: i,
+          key: row ? getRowKey(row) : defaultKeyExtractor(i),
+          row,
+        });
+      }
+      this.#itemsCache = {key: itemsKey, items};
+    }
+
+    const total =
+      count ??
+      (rows.atStart && rows.atEnd
+        ? rows.rowsLength
+        : hasReachedStart && hasReachedEnd
+          ? estimatedTotal
+          : undefined);
+
+    return {
+      items,
+      spaceBefore: rows.atStart ? 0 : rowsBefore * rowEstimate,
+      spaceAfter: rowsAfter * rowEstimate,
+      rowAt: rows.rowAt,
+      complete: rows.complete,
+      rowsEmpty: count === undefined ? rows.rowsEmpty : count === 0,
+      permalinkNotFound: rows.permalinkNotFound,
+      estimatedTotal: effectiveEstimatedTotal,
+      total,
+      settled: this.#settled,
+      debug: {current: this.#anchorState},
+    };
+  }
+
+  #notify(): void {
+    for (const listener of this.#listeners) {
+      listener();
+    }
+  }
+
+  #setPaging(next: PagingState<TListContextParams, TStartRow>): void {
+    if (next !== this.#paging) {
+      this.#paging = next;
+      this.#version++;
+    }
+  }
+
+  // Replace the paging anchor. `totalDelta` grows the estimated total in the
+  // same (atomic) update when the anchor change relabels the virtual
+  // coordinate space; the manual anchoring re-pins the reference row across
+  // the relabel, so the visible content stays put.
+  #setAnchor(anchor: Anchor<TStartRow>, totalDelta = 0): void {
+    const s = this.#paging;
+    this.#setPaging({
+      ...s,
+      estimatedTotal: s.estimatedTotal + totalDelta,
+      queryAnchor: {...s.queryAnchor, anchor},
+    });
+  }
+
+  // ---- scroll geometry -------------------------------------------------------
+
+  #scrollOffset(el: HTMLElement): number {
+    return this.#adapter.scrollElement(el).scrollTop;
+  }
+
+  #viewportRect(el: HTMLElement): ScrollRect {
+    const se = this.#adapter.scrollElement(el);
+    return {width: se.clientWidth, height: se.clientHeight};
+  }
+
+  // Scroll to an absolute offset, skipping no-op writes (same rounded offset).
+  // Returns whether it actually wrote — i.e. whether the position moved.
+  #setScrollTop(top: number): boolean {
+    const el = this.#el;
+    if (el && Math.round(this.#scrollOffset(el)) !== Math.round(top)) {
+      this.#programmaticScroll = true;
+      this.#adapter.scrollElement(el).scrollTop = top;
+      return true;
+    }
+    return false;
+  }
+
+  // ---- manual, momentum-safe scroll anchoring --------------------------------
+  // Native overflow-anchor is disabled in manual mode, so we keep the viewport
+  // visually stable ourselves: pin one keyed "reference" row; whenever the
+  // loaded rows change size above it, measure how far it moved and put it back.
+  // Idle we fold the correction into scrollTop; during a touch gesture we hold
+  // it as a margin-top on the first rendered row — writing scrollTop
+  // mid-momentum is ignored / cancels the fling on iOS, while a layout shift
+  // is fine — and reconcile margin→scrollTop when the gesture ends.
+
+  // Apply the held correction as a margin-top on the first rendered row (px is
+  // -pendingJump: negative pulls the content up).
+  #applyHold(px: number): void {
+    const el = this.#el;
+    const first = el ? firstRow(el) : null;
+    const prev = this.#holdEl;
+    if (prev && prev !== first) prev.style.marginTop = '';
+    this.#holdEl = px !== 0 ? first : null;
+    if (first) first.style.marginTop = px !== 0 ? `${px}px` : '';
+  }
+
+  // If paging replaced the first row while a hold is applied, move the margin
+  // to the new first row (pre-paint, so nothing shifts visibly).
+  #migrateHold(): void {
+    if (this.#holdEl === null) return;
+    const el = this.#el;
+    const first = el ? firstRow(el) : null;
+    if (first !== this.#holdEl) {
+      this.#applyHold(-this.#anchorState.pendingJump);
+    }
+  }
+
+  // A row rect's top offset from the viewport top, the held margin folded out.
+  #anchorOffsetOf(el: HTMLElement, rect: DOMRect): number {
+    return (
+      rect.top - this.#adapter.viewportTop(el) + this.#anchorState.pendingJump
+    );
+  }
+
+  #refreshAnchor(): void {
+    const el = this.#el;
+    if (!el) return;
+    const vTop = this.#adapter.viewportTop(el);
+    // Top-most visible row (first whose bottom is below the viewport top), the
+    // same reference the browser's native scroll anchoring would pick.
+    let ref: HTMLElement | null = null;
+    for (const child of queryRows(el)) {
+      if (child.getBoundingClientRect().bottom > vTop + 0.5) {
+        ref = child;
+        break;
+      }
+    }
+    this.#anchorKey = ref?.getAttribute(VROW_KEY_ATTR) ?? null;
+    this.#anchorOffset = ref
+      ? this.#anchorOffsetOf(el, ref.getBoundingClientRect())
+      : 0;
+  }
+
+  // The single correction choke point: idle → scrollTop; mid-gesture → hold as
+  // the first-row margin, owed to the reconcile at gesture end.
+  #compensate(delta: number): void {
+    const el = this.#el;
+    if (!el) return;
+    if (this.#anchorState.isScrolling && this.#touchScroll) {
+      this.#anchorState.pendingJump += delta;
+      // Unlike the scrollTop path (which moves the settled layout back to the
+      // target), the hold leaves the reference's settled position shifted by
+      // `delta`. Re-baseline the target so we don't keep re-compensating the
+      // same growth; the owed jump is flushed at reconcile.
+      this.#anchorOffset += delta;
+      this.#applyHold(-this.#anchorState.pendingJump);
+    } else {
+      this.#setScrollTop(this.#scrollOffset(el) + delta);
+    }
+  }
+
+  #measureAndCompensate(): void {
+    // Stand down while another mechanism owns the scroll position: a permalink
+    // jump scrolling its target to the top, or a list-context change resetting
+    // the list.
+    if (
+      !this.#manual() ||
+      this.#anchorSuppressed ||
+      !this.#isListContextCurrent() ||
+      this.#pendingPermalinkScroll !== null
+    ) {
+      return;
+    }
+    const el = this.#el;
+    if (!el) return;
+    // If paging swapped out the row carrying the held margin, re-pin it before
+    // measuring so the hold isn't double-counted as movement.
+    this.#migrateHold();
+    // Match native scroll anchoring, which the spec suppresses at scroll
+    // offset 0: a prepend there should be *revealed* (push content down), not
+    // compensated away. Re-base to the new top row instead of pinning the old
+    // one. (`<= 0` also covers iOS rubber-band overscroll.)
+    if (this.#scrollOffset(el) <= 0) {
+      this.#refreshAnchor();
+      return;
+    }
+    const key = this.#anchorKey;
+    const ref = key !== null ? findRow(el, key) : null;
+    if (!ref) {
+      // No valid reference yet, or it scrolled out of the loaded window —
+      // adopt the current topmost visible row.
+      this.#refreshAnchor();
+      return;
+    }
+    const delta =
+      this.#anchorOffsetOf(el, ref.getBoundingClientRect()) -
+      this.#anchorOffset;
+    if (Math.abs(delta) < 0.5) return;
+    this.#compensate(delta);
+  }
+
+  // Fold any owed jump into scrollTop while the margin still holds the pixels,
+  // then clear the held margin (one paint, no visible jump).
+  #flushHold(): boolean {
+    const el = this.#el;
+    if (el && this.#anchorState.pendingJump !== 0) {
+      this.#setScrollTop(
+        this.#scrollOffset(el) + this.#anchorState.pendingJump,
+      );
+      this.#anchorState.pendingJump = 0;
+      this.#applyHold(0);
+      return true;
+    }
+    return false;
+  }
+
+  // End of a scroll gesture: reconcile the held margin, re-base the anchor,
+  // and re-evaluate paging at the settled position.
+  #endScrolling(): void {
+    if (!this.#anchorState.isScrolling) return;
+    this.#anchorState.isScrolling = false;
+    this.#touchScroll = false;
+    this.#fingerDown = false;
+    clearTimeout(this.#idleTimer);
+    this.#flushHold();
+    this.#refreshAnchor();
+    this.#evaluate();
+  }
+
+  // Lift anchoring suppression once the reset list has loaded, and adopt a
+  // fresh reference from the settled list.
+  #liftAnchorSuppression(): void {
+    if (
+      this.#anchorSuppressed &&
+      this.#isListContextCurrent() &&
+      this.#rows.complete
+    ) {
+      this.#anchorSuppressed = false;
+      this.#refreshAnchor();
+    }
+  }
+
+  // ---- event handlers --------------------------------------------------------
+
+  #scheduleIdleCheck(): void {
+    clearTimeout(this.#idleTimer);
+    this.#idleTimer = setTimeout(() => this.#tryEndScroll(), IDLE_DEBOUNCE_MS);
+  }
+
+  #tryEndScroll(): void {
+    // Never end while a finger is down or momentum may still be gliding — a
+    // scrollTop write then would cancel the fling (the classic iOS jolt).
+    if (this.#fingerDown || Date.now() < this.#momentumGuardUntil) {
+      this.#scheduleIdleCheck();
+      return;
+    }
+    const before = this.#version;
+    this.#endScrolling();
+    if (this.#version !== before) this.#notify();
+  }
+
+  #onScroll = (): void => {
+    const programmatic = this.#programmaticScroll;
+    this.#programmaticScroll = false;
+    // Manual anchoring only: a user / momentum scroll (not our own
+    // compensation / reconcile / restore / permalink write) marks us as
+    // scrolling — via scroll events, not only touchstart, so it also fires for
+    // trackpad / wheel scrolling that emits no touch events — and re-bases the
+    // anchor.
+    if (this.#manual() && !programmatic) {
+      this.#anchorState.isScrolling = true;
+      this.#refreshAnchor();
+      if (!this.#fingerDown) this.#scheduleIdleCheck();
+    }
+    this.#resetSettleTimer();
+    const before = this.#version;
+    this.#evaluate();
+    if (this.#version !== before) this.#notify();
+  };
+
+  #onScrollEnd = (): void => {
+    if (!this.#manual()) return;
+    if (!this.#fingerDown) {
+      const before = this.#version;
+      this.#endScrolling();
+      if (this.#version !== before) this.#notify();
+    }
+  };
+
+  #onTouchStart = (): void => {
+    this.#fingerDown = true;
+    this.#touchScroll = true;
+    this.#anchorState.isScrolling = true;
+    clearTimeout(this.#idleTimer);
+  };
+
+  #onTouchEnd = (): void => {
+    this.#fingerDown = false;
+    this.#momentumGuardUntil = Date.now() + MOMENTUM_GUARD_MS;
+    this.#scheduleIdleCheck();
+  };
+
+  // Scroll-driven evaluation (replaces the old scrollTick re-render): paging,
+  // page size, and persist scheduling react to fresh DOM geometry directly.
+  #evaluate(): void {
+    this.#updatePageSize();
+    this.#evaluatePaging();
+    this.#schedulePersist();
+  }
+
+  // ---- settle ----------------------------------------------------------------
+
+  #resetSettleTimer(): void {
+    if (this.#settled) {
+      this.#settled = false;
+      this.#version++;
+    }
+    clearTimeout(this.#settleTimer);
+    this.#settleTimer = setTimeout(() => {
+      this.#settled = true;
+      this.#version++;
+      this.#options.onSettled?.();
+      this.#notify();
+    }, this.#options.settleTime ?? 2000);
+  }
+
+  // ---- rows/options-driven transitions (afterDOMUpdate) -----------------------
+
+  #updatePageSize(): void {
+    const el = this.#el;
+    const height = el ? this.#viewportRect(el).height : 0;
+    const newPageSize =
+      height > 0
+        ? Math.max(
+            MIN_PAGE_SIZE,
+            makeEven(Math.ceil(height / this.#rowEstimate()) * 3),
+          )
+        : MIN_PAGE_SIZE;
+    if (newPageSize > this.#pageSize) {
+      this.#pageSize = newPageSize;
+      this.#version++;
+    }
+  }
+
+  #applyReachedLatches(): void {
+    const s = this.#paging;
+    const hasReachedStart = s.hasReachedStart || this.#rows.atStart;
+    const hasReachedEnd = s.hasReachedEnd || this.#rows.atEnd;
+    if (
+      hasReachedStart !== s.hasReachedStart ||
+      hasReachedEnd !== s.hasReachedEnd
+    ) {
+      this.#setPaging({...s, hasReachedStart, hasReachedEnd});
+    }
+  }
+
+  // The estimated total is a monotonic high-water mark of the discovered
+  // extent: propose the current extent (exact when both ends are loaded) and
+  // keep the max.
+  #bumpEstimatedTotal(): void {
+    const rows = this.#rows;
+    if (!rows.complete) return;
+    const proposed =
+      rows.atStart && rows.atEnd
+        ? rows.rowsLength
+        : rows.firstRowIndex + rows.rowsLength;
+    if (proposed > this.#paging.estimatedTotal) {
+      this.#setPaging({...this.#paging, estimatedTotal: proposed});
+    }
+  }
+
+  // Keep the anchor index non-negative and collapse phantom space at the top.
+  // Both branches relabel the virtual coordinate space, so the estimated total
+  // moves by the same offset (atomically, via #setAnchor).
+  #relabelAnchor(): void {
+    const rows = this.#rows;
+    if (rows.rowsEmpty || !this.#isListContextCurrent()) {
+      return;
+    }
+    const anchor = this.#paging.queryAnchor.anchor;
+    if (rows.firstRowIndex < 0) {
+      const placeholderRows = !rows.atStart ? NUM_ROWS_FOR_LOADING_SKELETON : 0;
+      const offset = -rows.firstRowIndex + placeholderRows;
+      this.#setAnchor({...anchor, index: anchor.index + offset}, offset);
+      return;
+    }
+    if (rows.atStart && rows.firstRowIndex > 0) {
+      this.#setAnchor(TOP_ANCHOR as Anchor<TStartRow>, -rows.firstRowIndex);
+    }
+  }
+
+  // The restore / context-reset / permalink-navigation block. Runs only when
+  // its inputs changed (the old effect's dependency semantics): a new
+  // persisted state, a new permalinkID, or a context mismatch.
+  #restoreOrReset(): void {
+    const eff = this.#effectiveScrollState();
+    const {permalinkID, listContextParams} = this.#options;
+    const scrollStateChanged = eff !== this.#appliedScrollState;
+    const permalinkChanged = permalinkID !== this.#appliedPermalinkID;
+    this.#appliedScrollState = eff;
+    this.#appliedPermalinkID = permalinkID;
+
+    if (
+      this.#isListContextCurrent() &&
+      !scrollStateChanged &&
+      !permalinkChanged
+    ) {
+      return;
+    }
+
+    // A list-context (sort/filter) change resets the list: drop the anchor and
+    // suppress it until the new data loads, so we don't adopt or pin a stale
+    // reference row from the outgoing list.
+    if (!this.#isListContextCurrent()) {
+      this.#anchorKey = null;
+      this.#anchorSuppressed = true;
+    }
+
+    if (eff) {
+      // Re-base the anchor on a real restore (the write actually moves the
+      // position), but not on a same-position persist refresh which must
+      // leave the live anchor alone.
+      if (this.#setScrollTop(eff.scrollTop)) {
+        this.#anchorKey = null;
+      }
+      this.#setPaging(restoredPagingState(eff, listContextParams));
+    } else if (permalinkID) {
+      // Clicking an already-visible row just highlights it; a URL / deep-link
+      // navigation targets an off-screen (or not-yet-loaded) row, so re-anchor
+      // on it and scroll it to the top (in #retryPendingPermalinkScroll).
+      const el = this.#el;
+      const targetEl = el ? findRow(el, permalinkID) : null;
+      let targetVisible = false;
+      if (el && targetEl) {
+        const vTop = this.#adapter.viewportTop(el);
+        targetVisible = rectInViewport(
+          targetEl.getBoundingClientRect(),
+          vTop,
+          vTop + this.#viewportRect(el).height,
+        );
+      }
+      if (!targetVisible) {
+        this.#pendingPermalinkScroll = permalinkID;
+        if (!targetEl) {
+          // The row isn't loaded — re-anchor on it to load its page. (A
+          // loaded but off-screen row is left in place and just scrolled to.)
+          this.#setPaging(permalinkPagingState(permalinkID, listContextParams));
+        }
+      }
+    } else {
+      this.#anchorKey = null;
+      this.#setScrollTop(0);
+      this.#setPaging({
+        estimatedTotal: 0,
+        hasReachedStart: true,
+        hasReachedEnd: false,
+        queryAnchor: {anchor: TOP_ANCHOR as Anchor<TStartRow>, listContextParams},
+      });
+    }
+  }
+
+  // When a URL / deep-link navigation targeted an off-screen permalink row,
+  // scroll it to the top once it has rendered. Uses #setScrollTop (not
+  // scrollIntoView) so it flags the scroll as programmatic and moves the
+  // offset off zero — both needed to stop paging from re-anchoring to the top
+  // of the window while the target's context loads. The row can move as rows
+  // stream in around it, so retry on each change until loading settles.
+  #retryPendingPermalinkScroll(): void {
+    const pending = this.#pendingPermalinkScroll;
+    if (pending === null) return;
+    if (pending !== this.#options.permalinkID) {
+      // The permalink changed before we scrolled — drop the stale request.
+      this.#pendingPermalinkScroll = null;
+      return;
+    }
+    const el = this.#el;
+    if (!el) return;
+    const target = findRow(el, pending);
+    if (!target) {
+      // Not rendered yet — keep the request open and retry once it loads,
+      // unless the row genuinely doesn't exist.
+      if (this.#rows.permalinkNotFound) {
+        this.#pendingPermalinkScroll = null;
+      }
+      return;
+    }
+    // Commit any held margin so the target's rect and our write are relative
+    // to the real scroll offset, not a shifted layout.
+    this.#flushHold();
+    const before = this.#scrollOffset(el);
+    const delta =
+      target.getBoundingClientRect().top - this.#adapter.viewportTop(el);
+    if (Math.abs(delta) <= 1) {
+      this.#pendingPermalinkScroll = null; // reached the top
+      return;
+    }
+    this.#setScrollTop(before + delta);
+    // The row keeps moving as its context streams in (it may briefly clamp
+    // short of the top), so keep retrying until loading has settled.
+    if (this.#rows.complete) {
+      this.#pendingPermalinkScroll = null;
+    }
+  }
+
+  // One ResizeObserver over the loaded rows, re-attached when the row set
+  // changes: catches async row resizes (dynamic heights resolving after
+  // layout). border-box so padding/border changes are caught too.
+  #reobserveRows(): void {
+    const el = this.#el;
+    if (!this.#manual() || !el || typeof ResizeObserver === 'undefined') {
+      return;
+    }
+    const items = this.getSnapshot().items;
+    if (items === this.#observedItems && this.#resizeObserver) return;
+    this.#observedItems = items;
+    this.#resizeObserver?.disconnect();
+    this.#resizeObserver = new ResizeObserver(() => {
+      const before = this.#version;
+      this.#measureAndCompensate();
+      if (this.#version !== before) this.#notify();
+    });
+    for (const child of queryRows(el)) {
+      this.#resizeObserver.observe(child, {box: 'border-box'});
+    }
+  }
+
+  // ---- paging ----------------------------------------------------------------
+
+  #evaluatePaging(): void {
+    const rows = this.#rows;
+    if (!this.#isListContextCurrent() || rows.rowsEmpty || !rows.complete) {
+      return;
+    }
+    if (this.#programmaticScroll) return;
+    if (this.#pendingPermalinkScroll !== null) {
+      // A permalink jump is settling: don't re-anchor to the window edge while
+      // the target's context is still loading.
+      return;
+    }
+    const el = this.#el;
+    if (!el) return;
+
+    // Which loaded rows are currently visible (by data-index)? Rows are in
+    // DOM order, so once one starts below the viewport bottom the rest do too.
+    const elTop = this.#adapter.viewportTop(el);
+    const elBottom = elTop + this.#viewportRect(el).height;
+    let firstVisible = Infinity;
+    let lastVisible = -Infinity;
+    for (const child of queryRows(el)) {
+      const rect = child.getBoundingClientRect();
+      if (rect.top >= elBottom) break;
+      if (rectInViewport(rect, elTop, elBottom)) {
+        const idx = Number(child.getAttribute(VROW_INDEX_ATTR));
+        if (idx < firstVisible) firstVisible = idx;
+        if (idx > lastVisible) lastVisible = idx;
+      }
+    }
+    // Both distances are 0 when the corresponding edge row is visible.
+    const threshold = Math.max(
+      this.#options.overscan ?? 5,
+      getNearPageEdgeThreshold(this.#pageSize),
+    );
+
+    const updateAnchorForEdge = (
+      targetIndex: number,
+      type: 'forward' | 'backward',
+      indexOffset: number,
+    ) => {
+      const index = toBoundIndex(
+        targetIndex,
+        rows.firstRowIndex,
+        rows.rowsLength,
+      );
+      const startRow = rows.rowAt(index);
+      assert(startRow !== undefined || type === 'forward');
+      this.#setAnchor({
+        index: index + indexOffset,
+        kind: type,
+        startRow,
+      } as Anchor<TStartRow>);
+    };
+
+    if (firstVisible === Infinity) {
+      // No loaded row is visible: a far jump (scrollbar drag, instant
+      // scrollTop write) put the viewport entirely inside a spacer, so the
+      // edge-distance logic below has nothing to react to and paging would
+      // stall. Recover: a jump to the very top re-anchors at the start
+      // directly; otherwise cascade a page toward the viewport from the
+      // nearer edge of the loaded window (cursor-based paging can't teleport
+      // to an arbitrary index).
+      const first = firstRow(el);
+      if (!first) return;
+      if (first.getBoundingClientRect().top >= elBottom) {
+        // The window is below the viewport — the jump went up.
+        if (this.#scrollOffset(el) <= 0) {
+          this.#setAnchor(TOP_ANCHOR as Anchor<TStartRow>);
+        } else {
+          updateAnchorForEdge(rows.firstRowIndex, 'backward', 0);
+        }
+      } else {
+        // The window is above the viewport — the jump went down.
+        updateAnchorForEdge(
+          rows.firstRowIndex + rows.rowsLength - 1,
+          'forward',
+          1,
+        );
+      }
+      return;
+    }
+
+    if (rows.atStart && rows.firstRowIndex !== 0) {
+      this.#setAnchor(TOP_ANCHOR as Anchor<TStartRow>);
+      return;
+    }
+
+    const distanceFromStart = firstVisible - rows.firstRowIndex;
+    const distanceFromEnd =
+      rows.firstRowIndex + rows.rowsLength - 1 - lastVisible;
+
+    if (!rows.atStart && distanceFromStart <= threshold) {
+      updateAnchorForEdge(lastVisible + 2 * threshold, 'backward', 0);
+      return;
+    }
+    if (!rows.atEnd && distanceFromEnd <= threshold) {
+      updateAnchorForEdge(firstVisible - 2 * threshold, 'forward', 1);
+    }
+  }
+
+  // ---- persistence -----------------------------------------------------------
+
+  #persistKey(): string {
+    const s = this.#paging;
+    return `${JSON.stringify(s.queryAnchor.anchor)}:${this.#effectiveEstimatedTotal()}:${s.hasReachedStart}:${s.hasReachedEnd}`;
+  }
+
+  // Schedule a persist when persist-relevant state changed since the last
+  // schedule (the old effect's dependency semantics; scroll events schedule
+  // unconditionally via #evaluate → #schedulePersist).
+  #schedulePersistIfChanged(): void {
+    const key = this.#persistKey();
+    if (key !== this.#lastPersistKey) {
+      this.#schedulePersist(key);
+    }
+  }
+
+  #schedulePersist(key = this.#persistKey()): void {
+    const {onScrollStateChange} = this.#options;
+    if (!this.#isListContextCurrent() || !onScrollStateChange) return;
+    this.#lastPersistKey = key;
+    // Capture at schedule time (matches the old effect's closure semantics).
+    const anchor = this.#paging.queryAnchor.anchor;
+    const estimatedTotal = this.#effectiveEstimatedTotal();
+    const {hasReachedStart, hasReachedEnd} = this.#paging;
+    const {listContextParams} = this.#options;
+    clearTimeout(this.#persistTimer);
+    this.#persistTimer = setTimeout(() => {
+      const el = this.#el;
+      onScrollStateChange({
+        anchor,
+        // The logical committed offset: if a gesture is mid-flight with an
+        // owed jump held in the first-row margin, fold it in so restore lands
+        // right.
+        scrollTop: el
+          ? this.#scrollOffset(el) + this.#anchorState.pendingJump
+          : 0,
+        estimatedTotal,
+        hasReachedStart,
+        hasReachedEnd,
+        listContextParams,
+      });
+    }, PERSIST_DEBOUNCE_MS);
+  }
+}
+
+/**
+ * Clamps an index to be within the valid range of rows.
+ */
+function toBoundIndex(
+  targetIndex: number,
+  firstRowIndex: number,
+  rowsLength: number,
+): number {
+  if (rowsLength === 0) {
+    return firstRowIndex;
+  }
+  return Math.max(
+    firstRowIndex,
+    Math.min(firstRowIndex + rowsLength - 1, targetIndex),
+  );
+}
+
+/**
+ * Calculates the threshold for when to trigger loading more rows.
+ */
+function getNearPageEdgeThreshold(pageSize: number) {
+  return Math.ceil(pageSize / 10);
+}
+
+function makeEven(n: number) {
+  return n % 2 === 0 ? n : n + 1;
+}

--- a/src/core/virtualizer.ts
+++ b/src/core/virtualizer.ts
@@ -132,12 +132,6 @@ export type VirtualizerSnapshot<TRow> = {
   estimatedTotal: number;
   total: number | undefined;
   settled: boolean;
-  debug: {
-    readonly current: {
-      readonly isScrolling: boolean;
-      readonly pendingJump: number;
-    };
-  };
 };
 
 const EMPTY_ROWS: RowsSnapshot<unknown> = {
@@ -225,7 +219,7 @@ export class ZeroVirtualizer<TListContextParams, TRow, TStartRow> {
   #gestureScrolled = false;
   #settleTimer: ReturnType<typeof setTimeout> | undefined;
   #persistTimer: ReturnType<typeof setTimeout> | undefined;
-  // The live anchoring state; also exposed (read-only) as `debug`.
+  // The live anchoring state.
   readonly #anchorState = {isScrolling: false, pendingJump: 0};
   // The row element currently carrying the held margin.
   #holdEl: HTMLElement | null = null;
@@ -559,7 +553,6 @@ export class ZeroVirtualizer<TListContextParams, TRow, TStartRow> {
       estimatedTotal: effectiveEstimatedTotal,
       total,
       settled: this.#settled,
-      debug: {current: this.#anchorState},
     };
   }
 

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -1,24 +1,26 @@
+export {rowAttributes} from '../core/dom.ts';
+export {
+  elementScrollAdapter,
+  windowScrollAdapter,
+  type ScrollAdapter,
+  type ScrollRect,
+} from '../core/scroll-adapter.ts';
 export type {
+  AnchoringMode,
   GetPageQuery,
   GetPageQueryOptions,
   GetQueryReturnType,
   GetSingleQuery,
   GetSingleQueryOptions,
   QueryResult,
-} from './use-rows.ts';
+  ScrollHistoryState,
+  VirtualRow,
+} from '../core/types.ts';
 export {useHistoryScrollState} from './use-history-scroll-state.ts';
 export {useStickToBottom, type StickOptions} from './use-stick-to-edge.ts';
 export {
-  elementScrollAdapter,
-  rowAttributes,
   useZeroVirtualizer,
   useZeroWindowVirtualizer,
-  windowScrollAdapter,
-  type AnchoringMode,
-  type ScrollAdapter,
-  type ScrollHistoryState,
-  type ScrollRect,
   type UseZeroVirtualizerOptions,
-  type VirtualRow,
   type ZeroVirtualizerResult,
 } from './use-zero-virtualizer.ts';

--- a/src/react/use-history-scroll-state.ts
+++ b/src/react/use-history-scroll-state.ts
@@ -1,6 +1,6 @@
 import {useCallback, useMemo} from 'react';
 import {useHistoryState} from './use-history-state.ts';
-import type {ScrollHistoryState} from './use-zero-virtualizer.ts';
+import type {ScrollHistoryState} from '../core/types.ts';
 
 const DEFAULT_KEY = 'scrollState';
 

--- a/src/react/use-history-state.ts
+++ b/src/react/use-history-state.ts
@@ -1,48 +1,28 @@
 import {useSyncExternalStore} from 'react';
+import {
+  getHistoryStateServerSnapshot,
+  getHistoryStateSnapshot,
+  subscribeHistoryState,
+  updateHistoryState,
+} from '../core/history-state.ts';
 
 /**
- * A React hook that provides access to the Navigation API's current entry state,
- * synchronized with React's rendering cycle via `useSyncExternalStore`.
+ * A React hook that provides access to the Navigation API's current entry
+ * state, synchronized with React's rendering cycle via `useSyncExternalStore`.
+ * The store itself is framework-free (see core/history-state.ts).
  *
- * Returns a tuple of the current history state and a setter function that calls
- * `navigation.updateCurrentEntry` to update it.
+ * Returns a tuple of the current history state and a setter function that
+ * calls `navigation.updateCurrentEntry` to update it.
  */
 export function useHistoryState(): [
   state: unknown,
   setState: (state: unknown) => void,
 ] {
   const state = useSyncExternalStore(
-    subscribeState,
-    getSnapshot,
-    getServerSnapshot,
+    subscribeHistoryState,
+    getHistoryStateSnapshot,
+    getHistoryStateServerSnapshot,
   );
 
-  return [state, updateCurrentEntryState];
-}
-
-let currentSnapshot: unknown = null;
-let currentSnapshotString = 'null';
-
-function getSnapshot(): unknown {
-  const newSnapshot = navigation.currentEntry?.getState();
-  const newSnapshotString = JSON.stringify(newSnapshot);
-  if (newSnapshotString !== currentSnapshotString) {
-    currentSnapshot = newSnapshot;
-    currentSnapshotString = newSnapshotString;
-  }
-  return currentSnapshot;
-}
-
-function getServerSnapshot() {
-  return null;
-}
-
-function updateCurrentEntryState(state: unknown) {
-  navigation.updateCurrentEntry({state});
-}
-
-function subscribeState(onStoreChange: () => void) {
-  navigation.addEventListener('currententrychange', onStoreChange);
-  return () =>
-    navigation.removeEventListener('currententrychange', onStoreChange);
+  return [state, updateHistoryState];
 }

--- a/src/react/use-rows.ts
+++ b/src/react/use-rows.ts
@@ -1,106 +1,38 @@
+import {useQuery} from '@rocicorp/zero/react';
+import {useMemo} from 'react';
+import {
+  assembleRows,
+  buildAfterQuery,
+  buildMainQuery,
+  buildSingleQuery,
+  permalinkMissing,
+  type RowsSnapshot,
+} from '../core/rows.ts';
 import type {
-  DefaultContext,
-  DefaultSchema,
-  QueryOrQueryRequest,
-} from '@rocicorp/zero';
-import {useQuery, type UseQueryOptions} from '@rocicorp/zero/react';
-import {useCallback} from 'react';
-import {assert, unreachable} from '../asserts.ts';
+  Anchor,
+  GetPageQuery,
+  GetSingleQuery,
+} from '../core/types.ts';
+
+// Re-exported so existing imports of these (previously defined here) keep
+// working; they now live in the framework-free core.
+export type {
+  Anchor,
+  GetPageQuery,
+  GetPageQueryOptions,
+  GetQueryReturnType,
+  GetSingleQuery,
+  GetSingleQueryOptions,
+  QueryOptions,
+  QueryResult,
+} from '../core/types.ts';
 
 /**
- * Represents a position in the virtualized list used for pagination.
- *
- * @typeParam TStartRow - The type of data needed to anchor pagination
- */
-export type Anchor<TStartRow> =
-  | Readonly<{
-      index: number;
-      kind: 'forward';
-      startRow?: TStartRow | undefined;
-    }>
-  | Readonly<{
-      index: number;
-      kind: 'backward';
-      startRow: TStartRow;
-    }>
-  | Readonly<{
-      index: number;
-      kind: 'permalink';
-      id: string;
-    }>;
-
-/** Result returned by query functions: a query plus optional per-query options. */
-export type QueryResult<TReturn> = {
-  query: GetQueryReturnType<TReturn>;
-  options?: UseQueryOptions;
-};
-
-/**
- * Options passed to {@link GetPageQuery}.
- *
- * @typeParam TStartRow - The type of data needed to anchor pagination
- */
-export type GetPageQueryOptions<TStartRow> = {
-  /** The maximum number of rows to return */
-  limit: number;
-  /** The start row data to anchor the query, or null if starting from the beginning */
-  start: TStartRow | null;
-  /** The direction to paginate ('forward' or 'backward') */
-  dir: 'forward' | 'backward';
-  /** Whether the list has been idle for `settleTime` ms */
-  settled: boolean;
-};
-
-/**
- * Function that returns a query for fetching a page of rows.
- *
- * @typeParam TRow - The type of row data returned from queries
- * @typeParam TStartRow - The type of data needed to anchor pagination
- */
-export type GetPageQuery<TRow, TStartRow> = (
-  options: GetPageQueryOptions<TStartRow>,
-) => QueryResult<TRow>;
-
-/**
- * Options passed to {@link GetSingleQuery}.
- */
-export type GetSingleQueryOptions = {
-  /** The ID of the row to fetch */
-  id: string;
-  /** Whether the list has been idle for `settleTime` ms */
-  settled: boolean;
-};
-
-/**
- * Function that returns a query for fetching a single row by ID.
- *
- * @typeParam TRow - The type of row data returned from queries
- */
-export type GetSingleQuery<TRow> = (
-  options: GetSingleQueryOptions,
-) => QueryResult<TRow | undefined>;
-
-/**
- * Return type of a Zero query or query request.
- *
- * @typeParam TReturn - The type of the query return value
- */
-export type GetQueryReturnType<TReturn> = QueryOrQueryRequest<
-  keyof DefaultSchema['tables'] & string,
-  // oxlint-disable-next-line no-explicit-any
-  any, // input
-  // oxlint-disable-next-line no-explicit-any
-  any, // output
-  DefaultSchema,
-  TReturn,
-  DefaultContext
->;
-
-/**
- * Internal hook that manages the fetching and caching of rows for the virtualizer.
- *
- * @typeParam TRow - The type of row data returned from queries
- * @typeParam TStartRow - The type of data needed to anchor pagination
+ * Internal hook that binds the virtualizer's staged queries to Zero's React
+ * bindings. All windowing math lives in the framework-free core
+ * ({@linkcode assembleRows}); this hook owns only the query staging — three
+ * `useQuery` slots, called unconditionally in the same order every render
+ * (queries 2 and 3 depend on query 1's result for permalink anchors).
  */
 export function useRows<TRow, TStartRow>({
   pageSize,
@@ -117,188 +49,54 @@ export function useRows<TRow, TStartRow>({
   getPageQuery: GetPageQuery<TRow, TStartRow>;
   getSingleQuery: GetSingleQuery<TRow>;
   toStartRow: (row: TRow) => TStartRow;
-}): {
-  rowAt: (index: number) => TRow | undefined;
-  rowsLength: number;
-  complete: boolean;
-  rowsEmpty: boolean;
-  atStart: boolean;
-  atEnd: boolean;
-  firstRowIndex: number;
-  permalinkNotFound: boolean;
-} {
-  const {kind, index: anchorIndex} = anchor;
-  const isPermalink = kind === 'permalink';
-  assert(!isPermalink || pageSize % 2 === 0);
-  const halfPageSize = pageSize / 2;
+}): RowsSnapshot<TRow> {
+  const inputs = {pageSize, anchor, settled};
 
-  // --- All hooks called unconditionally, in the same order on every render ---
-
-  // Hook 1: single-item lookup (permalink only; null otherwise keeps hook count stable)
-  const permalinkId = isPermalink
-    ? (anchor as Extract<Anchor<TStartRow>, {kind: 'permalink'}>).id
-    : '';
-  const singleResult_ = isPermalink
-    ? getSingleQuery({id: permalinkId, settled})
-    : null;
-  const [singleRow, singleResult] = useQuery(
-    singleResult_?.query ?? null,
-    singleResult_?.options,
-  );
+  // Stage 1: single-item lookup (permalink only; null keeps the slot stable).
+  const q1 = buildSingleQuery(inputs, getSingleQuery);
+  const [singleRow, singleResult] = useQuery(q1?.query ?? null, q1?.options);
   const typedSingleRow = singleRow as TRow | undefined;
-  const completeRow = singleResult.type === 'complete';
-  const permalinkNotFound =
-    isPermalink && completeRow && typedSingleRow === undefined;
+  const singleComplete = singleResult.type === 'complete';
 
+  const notFound = permalinkMissing(inputs, typedSingleRow, singleComplete);
   const singleStart = typedSingleRow ? toStartRow(typedSingleRow) : null;
-  const pageStart = !isPermalink
-    ? ((anchor as Extract<Anchor<TStartRow>, {kind: 'forward' | 'backward'}>)
-        .startRow ?? null)
-    : null;
 
-  // Hook 2: page-before rows (permalink) OR main page rows (forward/backward)
-  const q2Result = isPermalink
-    ? !permalinkNotFound && singleStart
-      ? getPageQuery({
-          limit: halfPageSize + 1,
-          start: singleStart,
-          dir: 'backward',
-          settled,
-        })
-      : null
-    : getPageQuery({
-        limit: pageSize + 1,
-        start: pageStart,
-        dir: kind as 'forward' | 'backward',
-        settled,
-      });
-  const [rows2, result2] = useQuery(q2Result?.query ?? null, q2Result?.options);
+  // Stage 2: page-before rows (permalink) OR the main page rows.
+  const q2 = buildMainQuery(inputs, getPageQuery, singleStart, notFound);
+  const [mainRows, mainResult] = useQuery(q2?.query ?? null, q2?.options);
 
-  // Hook 3: page-after rows (permalink only; null for forward/backward)
-  const q3Result =
-    isPermalink && !permalinkNotFound && singleStart
-      ? getPageQuery({
-          limit: halfPageSize,
-          start: singleStart,
-          dir: 'forward',
-          settled,
-        })
-      : null;
-  const [rows3, result3] = useQuery(q3Result?.query ?? null, q3Result?.options);
+  // Stage 3: page-after rows (permalink only).
+  const q3 = buildAfterQuery(inputs, getPageQuery, singleStart, notFound);
+  const [afterRows, afterResult] = useQuery(q3?.query ?? null, q3?.options);
 
-  // Derive values needed in useCallback before calling it
-  const typedRows2 = rows2 as unknown as TRow[] | undefined;
-  const typedRows3 = rows3 as unknown as TRow[] | undefined;
+  const mainComplete = mainResult.type === 'complete';
+  const afterComplete = afterResult.type === 'complete';
 
-  const rowsBeforeLength = typedRows2?.length ?? 0;
-  const rowsAfterLength = typedRows3?.length ?? 0;
-  const rowsBeforeSize = Math.min(rowsBeforeLength, halfPageSize);
-  const rowsAfterSize = Math.min(rowsAfterLength, halfPageSize - 1);
-
-  const typedPageRows = (typedRows2 ?? []) as TRow[];
-  const hasMoreRows = !isPermalink && typedPageRows.length > pageSize;
-  const paginatedRowsLength = hasMoreRows ? pageSize : typedPageRows.length;
-
-  // Hook 4: single unified rowAt — same hook, same dep-array size, every render
-  const rowAt = useCallback(
-    (index: number): TRow | undefined => {
-      switch (kind) {
-        case 'permalink': {
-          if (index === anchorIndex) {
-            return typedSingleRow;
-          }
-          if (index > anchorIndex) {
-            if (typedRows3 === undefined) return undefined;
-            const i = index - anchorIndex - 1;
-            return i < rowsAfterSize ? typedRows3[i] : undefined;
-          }
-          if (typedRows2 === undefined) return undefined;
-          const i = anchorIndex - index - 1;
-          return i < rowsBeforeSize ? typedRows2[i] : undefined;
-        }
-        case 'forward': {
-          const i = index - anchorIndex;
-          return i >= 0 && i < paginatedRowsLength
-            ? typedPageRows[i]
-            : undefined;
-        }
-        case 'backward': {
-          const i = anchorIndex - index - 1;
-          return i >= 0 && i < paginatedRowsLength
-            ? typedPageRows[i]
-            : undefined;
-        }
-        default:
-          unreachable(kind);
-      }
-    },
+  // Memoized so the snapshot (and its rowAt identity) is stable across
+  // renders whose query results didn't change.
+  return useMemo(
+    () =>
+      assembleRows(
+        {pageSize, anchor, settled},
+        {
+          singleRow: typedSingleRow,
+          singleComplete,
+          mainRows: mainRows as unknown as TRow[] | undefined,
+          mainComplete,
+          afterRows: afterRows as unknown as TRow[] | undefined,
+          afterComplete,
+        },
+      ),
     [
-      isPermalink,
-      kind,
-      anchorIndex,
+      pageSize,
+      anchor,
+      settled,
       typedSingleRow,
-      typedRows2,
-      typedRows3,
-      rowsBeforeSize,
-      rowsAfterSize,
-      typedPageRows,
-      paginatedRowsLength,
+      singleComplete,
+      mainRows,
+      mainComplete,
+      afterRows,
+      afterComplete,
     ],
   );
-
-  // --- Pure value branching (no hooks below this line) ---
-
-  const complete2 = result2.type === 'complete';
-  const complete3 = result3.type === 'complete';
-
-  if (isPermalink) {
-    return {
-      rowAt,
-      rowsLength: permalinkNotFound
-        ? 0
-        : rowsBeforeSize + rowsAfterSize + (typedSingleRow ? 1 : 0),
-      complete: completeRow && (permalinkNotFound || (complete2 && complete3)),
-      rowsEmpty:
-        permalinkNotFound ||
-        typedSingleRow === undefined ||
-        (rowsBeforeSize === 0 && rowsAfterSize === 0),
-      atStart:
-        permalinkNotFound || (complete2 && rowsBeforeLength <= halfPageSize),
-      atEnd:
-        permalinkNotFound || (complete3 && rowsAfterLength <= halfPageSize - 1),
-      firstRowIndex: permalinkNotFound
-        ? anchorIndex
-        : anchorIndex - rowsBeforeSize,
-      permalinkNotFound,
-    };
-  }
-
-  kind satisfies 'forward' | 'backward';
-
-  if (kind === 'forward') {
-    return {
-      rowAt,
-      rowsLength: paginatedRowsLength,
-      complete: complete2,
-      rowsEmpty: typedPageRows.length === 0,
-      atStart: pageStart === null || anchorIndex === 0,
-      atEnd: complete2 && !hasMoreRows,
-      firstRowIndex: anchorIndex,
-      permalinkNotFound,
-    };
-  }
-
-  kind satisfies 'backward';
-  assert(pageStart !== null);
-
-  return {
-    rowAt,
-    rowsLength: paginatedRowsLength,
-    complete: complete2,
-    rowsEmpty: typedPageRows.length === 0,
-    atStart: complete2 && !hasMoreRows,
-    atEnd: false,
-    firstRowIndex: anchorIndex - paginatedRowsLength,
-    permalinkNotFound,
-  };
 }

--- a/src/react/use-rows.ts
+++ b/src/react/use-rows.ts
@@ -8,11 +8,7 @@ import {
   permalinkMissing,
   type RowsSnapshot,
 } from '../core/rows.ts';
-import type {
-  Anchor,
-  GetPageQuery,
-  GetSingleQuery,
-} from '../core/types.ts';
+import type {Anchor, GetPageQuery, GetSingleQuery} from '../core/types.ts';
 
 /**
  * Internal hook that binds the virtualizer's staged queries to Zero's React

--- a/src/react/use-rows.ts
+++ b/src/react/use-rows.ts
@@ -14,19 +14,6 @@ import type {
   GetSingleQuery,
 } from '../core/types.ts';
 
-// Re-exported so existing imports of these (previously defined here) keep
-// working; they now live in the framework-free core.
-export type {
-  Anchor,
-  GetPageQuery,
-  GetPageQueryOptions,
-  GetQueryReturnType,
-  GetSingleQuery,
-  GetSingleQueryOptions,
-  QueryOptions,
-  QueryResult,
-} from '../core/types.ts';
-
 /**
  * Internal hook that binds the virtualizer's staged queries to Zero's React
  * bindings. All windowing math lives in the framework-free core

--- a/src/react/use-stick-to-edge.ts
+++ b/src/react/use-stick-to-edge.ts
@@ -1,5 +1,8 @@
 import {useLayoutEffect, useRef} from 'react';
-import {elementScrollAdapter, type ScrollAdapter} from '../core/scroll-adapter.ts';
+import {
+  elementScrollAdapter,
+  type ScrollAdapter,
+} from '../core/scroll-adapter.ts';
 import {
   createStickToBottom,
   DEFAULT_STICK_SLACK,

--- a/src/react/use-stick-to-edge.ts
+++ b/src/react/use-stick-to-edge.ts
@@ -1,14 +1,10 @@
-import {useEffect, useLayoutEffect, useRef} from 'react';
+import {useLayoutEffect, useRef} from 'react';
+import {elementScrollAdapter, type ScrollAdapter} from '../core/scroll-adapter.ts';
 import {
-  elementScrollAdapter,
-  type ScrollAdapter,
-} from './use-zero-virtualizer.ts';
-
-/**
- * Slack (px) around the bottom edge so sub-pixel rounding or a stray fractional
- * scroll position doesn't count as "not at the bottom" and unstick you.
- */
-const DEFAULT_SLACK = 4;
+  createStickToBottom,
+  DEFAULT_STICK_SLACK,
+  type StickToBottomController,
+} from '../core/stick-to-bottom.ts';
 
 export type StickOptions = {
   /**
@@ -16,12 +12,12 @@ export type StickOptions = {
    * hook unconditionally, flip this instead). Defaults to `true`.
    */
   enabled?: boolean | undefined;
-  /** Px of slack around the edge (see {@link DEFAULT_SLACK}). */
+  /** Px of slack around the edge (defaults to {@link DEFAULT_STICK_SLACK}). */
   slack?: number | undefined;
   /**
    * How the scroll container is read and driven — pass the same adapter the
    * virtualizer uses ({@linkcode elementScrollAdapter} by default,
-   * {@linkcode windowScrollAdapter} for a window scroller).
+   * `windowScrollAdapter` for a window scroller).
    */
   adapter?: ScrollAdapter | undefined;
 };
@@ -29,66 +25,67 @@ export type StickOptions = {
 /**
  * Stick-to-bottom: when content grows, keep the viewport pinned to the bottom
  * — but only if the user was already parked there. The building block for a
- * chat / log UI.
+ * chat / log UI. Thin React binding over the core
+ * {@linkcode createStickToBottom} controller.
  *
  * This is a thin layer on top of scroll anchoring, not a replacement for it.
- * Anchoring keeps the view stable when off-screen content above changes (e.g.
- * loading older messages); the one thing it never does is *follow* new content
- * arriving at the bottom edge. That's this. Scroll away from the bottom and
- * the following stops (read history in peace); scroll back and it re-arms.
- *
- * There is deliberately no stick-to-*top* twin: scroll anchoring is suppressed
- * at scroll offset 0 (natively per the CSS spec, and the manual mode matches),
- * so content prepended while you're at the very top is already revealed.
+ * Anchoring keeps the view stable when off-screen content above changes; the
+ * one thing it never does is *follow* new content arriving at the bottom
+ * edge. That's this. There is deliberately no stick-to-*top* twin: scroll
+ * anchoring is suppressed at scroll offset 0 (natively per the CSS spec, and
+ * the manual mode matches), so content prepended while you're at the very top
+ * is already revealed.
  *
  * @param getScrollElement Returns the scroll container — the same element the
  *   virtualizer's `getScrollElement` returns.
  * @param dep A value that changes whenever the content can grow at the bottom
- *   (e.g. the newest row's key, the row count, or a measurement tick). The
- *   re-pin runs after each change, so it also re-sticks as dynamic rows settle.
+ *   (e.g. the newest row's key, the row count, or a measurement tick).
  */
 export function useStickToBottom(
   getScrollElement: () => HTMLElement | null,
   dep: unknown,
   {
     enabled = true,
-    slack = DEFAULT_SLACK,
+    slack = DEFAULT_STICK_SLACK,
     adapter = elementScrollAdapter,
   }: StickOptions = {},
 ): void {
-  // Whether the user is currently parked at the bottom. Updated on every
-  // scroll (i.e. *before* the content grows), so at grow-time it reflects the
-  // pre-growth position — which is the whole trick. Starts false (never yank
-  // a restored scroll position); the first measurement decides, and a freshly
-  // mounted short list measures as at-bottom, so a chat still starts stuck.
-  const stuckRef = useRef(false);
+  const ref = useRef<{
+    controller: StickToBottomController;
+    key: readonly [() => HTMLElement | null, ScrollAdapter, number];
+  } | null>(null);
 
-  // `dep` is deliberately in the deps: when the scroll container renders
-  // conditionally, `getScrollElement()` can be null on the first pass and
-  // nothing else here would ever re-run — the listener would never attach.
-  // Re-running per content tick guarantees we attach (and re-measure) once
-  // the element exists; the re-subscription is cheap.
-  useEffect(() => {
-    const el = getScrollElement();
-    if (!el || !enabled) return undefined;
-    const scroller = adapter.scrollElement(el);
-    const measure = () => {
-      stuckRef.current =
-        scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight <=
-        slack;
-    };
-    measure();
-    return adapter.subscribe(el, measure, () => {});
-  }, [getScrollElement, adapter, slack, enabled, dep]);
-
-  // After the content grows, snap back to the bottom if we were parked there.
-  // Layout effect (not passive) so it happens before paint — no flash of the
-  // un-followed position.
+  // Runs per content tick, pre-paint. `dep` is deliberately in the deps: when
+  // the scroll container renders conditionally, `getScrollElement()` can be
+  // null at first and nothing else would re-run — the controller attaches
+  // lazily on each tick until the element exists.
   useLayoutEffect(() => {
-    if (!enabled || !stuckRef.current) return;
-    const el = getScrollElement();
-    if (!el) return;
-    const scroller = adapter.scrollElement(el);
-    scroller.scrollTop = scroller.scrollHeight;
-  }, [dep, getScrollElement, adapter, enabled]);
+    if (!enabled) {
+      ref.current?.controller.detach();
+      ref.current = null;
+      return;
+    }
+    const key = [getScrollElement, adapter, slack] as const;
+    if (
+      !ref.current ||
+      ref.current.key[0] !== key[0] ||
+      ref.current.key[1] !== key[1] ||
+      ref.current.key[2] !== key[2]
+    ) {
+      ref.current?.controller.detach();
+      ref.current = {
+        controller: createStickToBottom(getScrollElement, adapter, slack),
+        key,
+      };
+    }
+    ref.current.controller.contentChanged();
+  }, [dep, enabled, getScrollElement, adapter, slack]);
+
+  useLayoutEffect(
+    () => () => {
+      ref.current?.controller.detach();
+      ref.current = null;
+    },
+    [],
+  );
 }

--- a/src/react/use-zero-virtualizer.ts
+++ b/src/react/use-zero-virtualizer.ts
@@ -5,15 +5,43 @@ import {
   useMemo,
   useRef,
   useState,
-  type Key,
 } from 'react';
 import {assert} from '../asserts.ts';
 import {
-  useRows,
-  type Anchor,
-  type GetPageQuery,
-  type GetSingleQuery,
-} from './use-rows.ts';
+  findRow,
+  firstRow,
+  queryRows,
+  rectInViewport,
+  VROW_INDEX_ATTR,
+  VROW_KEY_ATTR,
+} from '../core/dom.ts';
+import {
+  elementScrollAdapter,
+  windowScrollAdapter,
+  type ScrollAdapter,
+  type ScrollRect,
+} from '../core/scroll-adapter.ts';
+import type {
+  Anchor,
+  AnchoringMode,
+  GetPageQuery,
+  GetSingleQuery,
+  RowKey,
+  ScrollHistoryState,
+  VirtualRow,
+} from '../core/types.ts';
+import {useRows} from './use-rows.ts';
+
+// Re-exported so the public `./react` entry point is unchanged by the
+// core extraction (index.ts re-exports these from here).
+export {elementScrollAdapter, windowScrollAdapter};
+export type {ScrollAdapter, ScrollRect};
+export {rowAttributes} from '../core/dom.ts';
+export type {
+  AnchoringMode,
+  ScrollHistoryState,
+  VirtualRow,
+} from '../core/types.ts';
 
 // Make sure this is even since we half it for scroll state loading
 const MIN_PAGE_SIZE = 100;
@@ -27,38 +55,7 @@ const MOMENTUM_GUARD_MS = 180;
 // as ended, when the native `scrollend` event isn't available. Tune on device.
 const IDLE_DEBOUNCE_MS = 120;
 
-const defaultKeyExtractor = (index: number): Key => index;
-
-// The row-identification contract between the virtualizer and the rendered
-// rows: every row element (including loading placeholders) carries these two
-// attributes - they are how the virtualizer finds rows in the DOM (visible-row
-// detection for paging, the anchoring reference, permalink targets). Consumers
-// should spread {@linkcode rowAttributes} onto each row element.
-const VROW_INDEX_ATTR = 'data-vrow-index';
-const VROW_KEY_ATTR = 'data-vrow-key';
-
-/**
- * The attributes every rendered row (and loading placeholder) must carry, as an
- * object to spread onto the row element: `<div {...rowAttributes(index, key)}>`.
- * See {@linkcode VirtualRow} for `index` / `key`.
- */
-export function rowAttributes(
-  index: number,
-  key: Key,
-): {'data-vrow-index': number; 'data-vrow-key': Key} {
-  return {[VROW_INDEX_ATTR]: index, [VROW_KEY_ATTR]: key};
-}
-
-/**
- * How the viewport is kept stable as off-screen content resizes:
- * - `native`: rely on the browser's CSS `overflow-anchor` (simplest; used where
- *   it's reliable).
- * - `manual`: the momentum-safe manual anchoring (reference-row pinning, with
- *   touch-time corrections held as a first-row margin), for browsers without
- *   native scroll anchoring.
- * - `auto`: pick per {@linkcode detectNeedsManualAnchoring} (default).
- */
-export type AnchoringMode = 'auto' | 'manual' | 'native';
+const defaultKeyExtractor = (index: number): RowKey => index;
 
 // Use manual anchoring wherever the browser doesn't implement CSS scroll
 // anchoring - notably older versions of Safari. Feature detection, not UA
@@ -67,123 +64,11 @@ function detectNeedsManualAnchoring(): boolean {
   return typeof CSS === 'undefined' || !CSS.supports('overflow-anchor', 'auto');
 }
 
-/**
- * State object that captures the virtualizer's scroll position and pagination state.
- * Used for persisting and restoring the virtualizer state across navigation or page reloads.
- *
- * @typeParam TStartRow - The type of the start row data used for pagination anchoring
- */
-export type ScrollHistoryState<
-  TStartRow,
-  TListContextParams = unknown,
-> = Readonly<{
-  /** The anchor point for pagination (includes position, direction, and start row data) */
-  anchor: Anchor<TStartRow>;
-  /** The scroll position in pixels from the top of the scrollable container */
-  scrollTop: number;
-  /** The estimated total number of rows in the list */
-  estimatedTotal: number;
-  /** Whether the virtualizer has reached the start of the list */
-  hasReachedStart: boolean;
-  /** Whether the virtualizer has reached the end of the list */
-  hasReachedEnd: boolean;
-  /** The list context params active when this state was saved (used to invalidate stale state) */
-  listContextParams: TListContextParams;
-}>;
-
 const TOP_ANCHOR = Object.freeze({
   index: 0,
   kind: 'forward',
   startRow: undefined,
 }) satisfies Anchor<unknown>;
-
-/** The size of the scroll viewport. */
-export type ScrollRect = {width: number; height: number};
-
-/**
- * Abstracts the scroll container so the same virtualizer works whether the list
- * scrolls inside an element or scrolls the window. Mirrors the split TanStack
- * Virtual makes between its `element*` and `window*` scroll helpers.
- *
- * `el` is always the element the rows are rendered into (returned by
- * `getScrollElement`). For element scrolling it is also the scroll container;
- * for window scrolling the window is the scroll container and `el` is only used
- * to locate the rendered rows.
- */
-export type ScrollAdapter = {
-  /**
-   * The actual scrolling element: the overflow container itself for element
-   * scrolling, `document.scrollingElement` for window scrolling. Everything
-   * positional is derived from it - scroll offset (`scrollTop`), viewport size
-   * (`clientWidth`/`clientHeight`), content extent (`scrollHeight`),
-   * `overflow-anchor` toggling, and touch listeners (touches bubble to it).
-   */
-  scrollElement: (el: HTMLElement) => HTMLElement;
-  /**
-   * Top of the scroll viewport in client (getBoundingClientRect) coordinates;
-   * 0 for the window scroller. Row positions are measured against this. (The
-   * nearest TanStack Virtual concept is `scrollMargin`, but that is a static
-   * offset from the scroll origin rather than a client coordinate, so the name
-   * is not borrowed.)
-   */
-  viewportTop: (el: HTMLElement) => number;
-  /**
-   * Listen for `scroll` / `scrollend` on the scroll container (these don't
-   * bubble, so where to listen is adapter-specific: the element itself vs. the
-   * window). Returns an unsubscribe fn.
-   */
-  subscribe: (
-    el: HTMLElement,
-    onScroll: () => void,
-    onScrollEnd: () => void,
-  ) => () => void;
-};
-
-/** Scroll adapter for a list that scrolls inside an overflow element. */
-export const elementScrollAdapter: ScrollAdapter = {
-  scrollElement: el => el,
-  viewportTop: el => el.getBoundingClientRect().top,
-  subscribe: (el, onScroll, onScrollEnd) => {
-    el.addEventListener('scroll', onScroll, {passive: true});
-    el.addEventListener('scrollend', onScrollEnd);
-    return () => {
-      el.removeEventListener('scroll', onScroll);
-      el.removeEventListener('scrollend', onScrollEnd);
-    };
-  },
-};
-
-/** Scroll adapter for a list that scrolls the window. */
-export const windowScrollAdapter: ScrollAdapter = {
-  scrollElement: () =>
-    (document.scrollingElement as HTMLElement | null) ??
-    document.documentElement,
-  viewportTop: () => 0,
-  subscribe: (_el, onScroll, onScrollEnd) => {
-    window.addEventListener('scroll', onScroll, {passive: true});
-    window.addEventListener('scrollend', onScrollEnd);
-    return () => {
-      window.removeEventListener('scroll', onScroll);
-      window.removeEventListener('scrollend', onScrollEnd);
-    };
-  },
-};
-
-/**
- * A single item to render. Rows are rendered in normal document flow (no
- * absolute positioning), so there is no `start`/`size` - the browser lays them
- * out.
- *
- * @typeParam TRow - The type of row data returned from queries
- */
-export type VirtualRow<TRow> = {
-  /** The row's index in the (estimated) full list. */
-  index: number;
-  /** Stable key for React. Row id when loaded, otherwise index-derived. */
-  key: Key;
-  /** The row data, or undefined while the row is still loading. */
-  row: TRow | undefined;
-};
 
 /**
  * Options for configuring the Zero virtualizer.
@@ -219,7 +104,7 @@ export type UseZeroVirtualizerOptions<TListContextParams, TRow, TStartRow> = {
   anchoring?: AnchoringMode | undefined;
 
   /** Function that extracts a stable unique key from a row. */
-  getRowKey: (row: TRow) => Key;
+  getRowKey: (row: TRow) => RowKey;
 
   /** Parameters that define the list's query context (filters, sort order, etc.) */
   listContextParams: TListContextParams;
@@ -571,7 +456,7 @@ function useZeroVirtualizerImpl<TListContextParams, TRow, TStartRow>(
   // loads. It stays null when a permalink points at an already-visible row (e.g.
   // clicking a visible row), so clicking a row never scrolls it. Initialized for
   // a direct load (`/#id` with no restored scroll state).
-  const pendingPermalinkScrollRef = useRef<Key | null>(
+  const pendingPermalinkScrollRef = useRef<RowKey | null>(
     permalinkID && !effectiveScrollState ? permalinkID : null,
   );
 
@@ -623,7 +508,7 @@ function useZeroVirtualizerImpl<TListContextParams, TRow, TStartRow>(
   // writing scrollTop mid-momentum is ignored / cancels the fling on iOS, while a
   // layout shift is fine - and reconcile margin->scrollTop atomically when the
   // gesture ends.
-  const anchorKeyRef = useRef<Key | null>(null);
+  const anchorKeyRef = useRef<RowKey | null>(null);
   // The reference row's top offset from the viewport top, in the settled
   // (hold-free) frame - what the anchoring keeps stable across relabels and
   // off-screen resizes (matching native `overflow-anchor`, which anchors to the
@@ -1332,26 +1217,4 @@ function getNearPageEdgeThreshold(pageSize: number) {
 
 function makeEven(n: number) {
   return n % 2 === 0 ? n : n + 1;
-}
-
-/** All rendered row elements inside the container, in DOM order. */
-function queryRows(el: HTMLElement): Iterable<HTMLElement> {
-  return el.querySelectorAll<HTMLElement>(`[${VROW_INDEX_ATTR}]`);
-}
-
-/** The first rendered row element (the held-margin carrier), or null. */
-function firstRow(el: HTMLElement): HTMLElement | null {
-  return el.querySelector<HTMLElement>(`[${VROW_INDEX_ATTR}]`);
-}
-
-/** Find a rendered row element by its stable key. */
-function findRow(el: HTMLElement, key: Key): HTMLElement | null {
-  return el.querySelector<HTMLElement>(
-    `[${VROW_KEY_ATTR}="${CSS.escape(String(key))}"]`,
-  );
-}
-
-/** Whether a client-coordinate rect overlaps the `[top, bottom)` viewport band. */
-function rectInViewport(rect: DOMRect, top: number, bottom: number): boolean {
-  return rect.bottom > top && rect.top < bottom;
 }

--- a/src/react/use-zero-virtualizer.ts
+++ b/src/react/use-zero-virtualizer.ts
@@ -1,35 +1,16 @@
-import {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
-import {assert} from '../asserts.ts';
-import {
-  findRow,
-  firstRow,
-  queryRows,
-  rectInViewport,
-  VROW_INDEX_ATTR,
-  VROW_KEY_ATTR,
-} from '../core/dom.ts';
+import {useLayoutEffect, useReducer, useState} from 'react';
 import {
   elementScrollAdapter,
   windowScrollAdapter,
   type ScrollAdapter,
   type ScrollRect,
 } from '../core/scroll-adapter.ts';
-import type {
-  Anchor,
-  AnchoringMode,
-  GetPageQuery,
-  GetSingleQuery,
-  RowKey,
-  ScrollHistoryState,
-  VirtualRow,
-} from '../core/types.ts';
+import type {GetPageQuery, GetSingleQuery, RowKey} from '../core/types.ts';
+import {
+  ZeroVirtualizer,
+  type VirtualizerOptions,
+  type VirtualizerSnapshot,
+} from '../core/virtualizer.ts';
 import {useRows} from './use-rows.ts';
 
 // Re-exported so the public `./react` entry point is unchanged by the
@@ -43,1121 +24,113 @@ export type {
   VirtualRow,
 } from '../core/types.ts';
 
-// Make sure this is even since we half it for scroll state loading
-const MIN_PAGE_SIZE = 100;
-
-const NUM_ROWS_FOR_LOADING_SKELETON = 1;
-
-// After the finger lifts, assume momentum may still be gliding for at least this
-// long before an idle-timeout is allowed to conclude the gesture has ended.
-const MOMENTUM_GUARD_MS = 180;
-// How long the scroll must be quiet (no scroll events) before we treat a gesture
-// as ended, when the native `scrollend` event isn't available. Tune on device.
-const IDLE_DEBOUNCE_MS = 120;
-
-const defaultKeyExtractor = (index: number): RowKey => index;
-
-// Use manual anchoring wherever the browser doesn't implement CSS scroll
-// anchoring - notably older versions of Safari. Feature detection, not UA
-// sniffing; overridable via the `anchoring` option.
-function detectNeedsManualAnchoring(): boolean {
-  return typeof CSS === 'undefined' || !CSS.supports('overflow-anchor', 'auto');
-}
-
-const TOP_ANCHOR = Object.freeze({
-  index: 0,
-  kind: 'forward',
-  startRow: undefined,
-}) satisfies Anchor<unknown>;
-
 /**
- * Options for configuring the Zero virtualizer.
+ * Options for configuring the Zero virtualizer. The core options (see
+ * {@linkcode VirtualizerOptions}) plus the React-side wiring: the scroll
+ * element getter, the query functions (bound via `@rocicorp/zero/react`), and
+ * an optional custom scroll adapter.
  *
  * @typeParam TListContextParams - The type of parameters that define the list's query context
  * @typeParam TRow - The type of row data returned from queries
  * @typeParam TStartRow - The type of data needed to anchor pagination (typically a subset of TRow)
  */
-export type UseZeroVirtualizerOptions<TListContextParams, TRow, TStartRow> = {
-  /**
-   * Estimated size (px) of the row at `index`, used to size the spacers that
-   * stand in for the not-yet-loaded rows above and below the loaded window.
-   * Only an estimate - real row heights come from the DOM.
-   */
-  estimateSize: (index: number) => number;
+export type UseZeroVirtualizerOptions<TListContextParams, TRow, TStartRow> =
+  VirtualizerOptions<TListContextParams, TRow, TStartRow> & {
+    /** Returns the scrollable container element. */
+    getScrollElement: () => HTMLElement | null;
 
-  /**
-   * Number of extra rows of margin (beyond the viewport) to keep loaded, and
-   * how early to trigger loading the next page. Defaults to 5.
-   */
-  overscan?: number | undefined;
+    /** Function that returns a query for fetching a page of rows */
+    getPageQuery: GetPageQuery<TRow, TStartRow>;
+    /** Function that returns a query for fetching a single row by ID */
+    getSingleQuery: GetSingleQuery<TRow>;
+    /** Function to extract the start row data from a full row (for pagination anchoring) */
+    toStartRow: (row: TRow) => TStartRow;
 
-  /** Returns the scrollable container element. */
-  getScrollElement: () => HTMLElement | null;
-
-  /**
-   * Which anchoring strategy to use (see {@linkcode AnchoringMode}). Defaults to
-   * `'auto'`. In `'manual'` mode the virtualizer sets `overflow-anchor: none` on
-   * the scroll container and compensates itself; in `'native'` mode it sets
-   * `overflow-anchor: auto` and does nothing (the browser handles it). Either
-   * way, keep `overflow-anchor: none` on the spacer elements.
-   */
-  anchoring?: AnchoringMode | undefined;
-
-  /** Function that extracts a stable unique key from a row. */
-  getRowKey: (row: TRow) => RowKey;
-
-  /** Parameters that define the list's query context (filters, sort order, etc.) */
-  listContextParams: TListContextParams;
-
-  /**
-   * Optional exact total row count. When provided it replaces the internal
-   * estimate, which gives an accurate and *stable* scrollbar: the scroll extent
-   * is fixed up front, so the handle stays put as you scroll.
-   *
-   * When omitted, the total is unknown and estimated as a high-water mark of the
-   * rows discovered so far. That estimate only grows (never projects past what's
-   * loaded), so while scrolling forward into new rows the scroll extent keeps
-   * extending by ~a page at a time and the native scrollbar handle jumps. This is
-   * inherent to an unknown-length list - pass `count` whenever you can get it
-   * cheaply (e.g. a count query) to avoid it.
-   */
-  count?: number | undefined;
-
-  /** Optional ID to highlight/scroll to a specific row (permalink functionality) */
-  permalinkID?: string | null | undefined;
-
-  /** Function that returns a query for fetching a page of rows */
-  getPageQuery: GetPageQuery<TRow, TStartRow>;
-  /** Function that returns a query for fetching a single row by ID */
-  getSingleQuery: GetSingleQuery<TRow>;
-  /**
-   * Time in ms the list must remain unscrolled before it is considered "settled".
-   * When settled, query functions receive `{settled: true}` so they can return
-   * different options (e.g., longer TTL). Defaults to 2000.
-   */
-  settleTime?: number | undefined;
-  /** Function to extract the start row data from a full row (for pagination anchoring) */
-  toStartRow: (row: TRow) => TStartRow;
-
-  /**
-   * Optional current scroll state for restoring virtualizer position.
-   * If provided along with `onScrollStateChange`, enables state persistence.
-   */
-  scrollState?: ScrollHistoryState<TStartRow> | null | undefined;
-  /**
-   * Optional callback invoked when the virtualizer state changes.
-   * Use this to persist state (e.g., to browser history, local storage, etc.).
-   * Called with the new state approximately 100ms after scroll/pagination changes.
-   */
-  onScrollStateChange?: (state: ScrollHistoryState<TStartRow>) => void;
-
-  /**
-   * Optional callback invoked when the list becomes settled (no scroll
-   * activity for `settleTime` ms).
-   */
-  onSettled?: (() => void) | undefined;
-
-  /**
-   * How the scroll container is read and driven. Defaults to
-   * {@linkcode elementScrollAdapter} for {@linkcode useZeroVirtualizer} and
-   * {@linkcode windowScrollAdapter} for {@linkcode useZeroWindowVirtualizer}.
-   * Provide a custom adapter to scroll some other container.
-   */
-  scrollAdapter?: ScrollAdapter | undefined;
-};
-
-const createPermalinkAnchor = (id: string) =>
-  ({
-    id,
-    index: NUM_ROWS_FOR_LOADING_SKELETON,
-    kind: 'permalink',
-  }) as const;
-
-/**
- * Pairs the paging anchor with the list-context params (sort/filter) it was
- * created under, so the two can only change together. While they disagree with
- * the current props (`!isListContextCurrent` - e.g. right after a sort change
- * or browser back/forward), paging and count updates stand down: we never
- * query with an anchor from one context against the params of another.
- */
-type QueryAnchor<TListContextParams, TStartRow> = {
-  readonly anchor: Anchor<TStartRow>;
-  readonly listContextParams: TListContextParams;
-};
-
-/**
- * The virtualizer's pagination state. Kept in a single object so multi-field
- * updates - e.g. relabeling the anchor index together with the estimated total
- * - stay atomic.
- */
-type PagingState<TListContextParams, TStartRow> = {
-  estimatedTotal: number;
-  hasReachedStart: boolean;
-  hasReachedEnd: boolean;
-  queryAnchor: QueryAnchor<TListContextParams, TStartRow>;
-};
-
-// The paging state constructed from a persisted scroll state / a permalink is
-// needed twice each: in the useState initializer (mount - avoids Strict Mode
-// double-mounting the rows) and in the restore/reset layout effect (post-mount
-// navigation). These constructors keep the two sites from drifting.
-
-function restoredPagingState<TListContextParams, TStartRow>(
-  state: ScrollHistoryState<TStartRow>,
-  listContextParams: TListContextParams,
-): PagingState<TListContextParams, TStartRow> {
-  return {
-    estimatedTotal: state.estimatedTotal,
-    hasReachedStart: state.hasReachedStart,
-    hasReachedEnd: state.hasReachedEnd,
-    queryAnchor: {anchor: state.anchor, listContextParams},
+    /**
+     * How the scroll container is read and driven. Defaults to
+     * {@linkcode elementScrollAdapter} for {@linkcode useZeroVirtualizer} and
+     * {@linkcode windowScrollAdapter} for {@linkcode useZeroWindowVirtualizer}.
+     * Provide a custom adapter to scroll some other container.
+     */
+    scrollAdapter?: ScrollAdapter | undefined;
   };
-}
-
-function permalinkPagingState<TListContextParams, TStartRow>(
-  id: string,
-  listContextParams: TListContextParams,
-): PagingState<TListContextParams, TStartRow> {
-  return {
-    estimatedTotal: NUM_ROWS_FOR_LOADING_SKELETON,
-    hasReachedStart: false,
-    hasReachedEnd: false,
-    queryAnchor: {anchor: createPermalinkAnchor(id), listContextParams},
-  };
-}
 
 /**
- * Result object returned by the useZeroVirtualizer hook.
+ * Result object returned by the useZeroVirtualizer hook: the loaded rows to
+ * render between two spacers, plus load/paging status. See
+ * {@linkcode VirtualizerSnapshot} for field semantics. The object identity is
+ * stable between renders whose content didn't change.
  *
  * @typeParam TRow - The type of row data returned from queries
  */
-export type ZeroVirtualizerResult<TRow> = {
-  /**
-   * The loaded rows to render, in order. Render them in normal flow between a
-   * top spacer of height {@linkcode spaceBefore} and a bottom spacer of height
-   * {@linkcode spaceAfter}. Each row must carry a stable per-row key so its DOM
-   * node persists across paging (that identity is what the virtualizer's manual
-   * anchoring measures against).
-   */
-  items: ReadonlyArray<VirtualRow<TRow>>;
-  /** Height (px) of the top spacer, standing in for unloaded rows above. */
-  spaceBefore: number;
-  /** Height (px) of the bottom spacer, standing in for unloaded rows below. */
-  spaceAfter: number;
-  /** Function to get the row data at a specific index, or undefined if not loaded */
-  rowAt: (index: number) => TRow | undefined;
-  /** Whether all initially requested data has finished loading */
-  complete: boolean;
-  /** Whether the list is empty (no rows exist matching the query) */
-  rowsEmpty: boolean;
-  /** Whether the specified permalinkID was not found in the query results */
-  permalinkNotFound: boolean;
-  /** Estimated total number of rows (may be inexact until both ends are reached) */
-  estimatedTotal: number;
-  /** Exact total number of rows, or undefined if not yet known (requires reaching both ends) */
-  total: number | undefined;
-  /** Whether the list has been unscrolled for at least `settleTime` ms */
-  settled: boolean;
-  /**
-   * Live internal anchoring state, for debugging / demos only (a stable ref; read
-   * `.current` - it does not trigger re-renders). Not part of the stable API.
-   */
-  debug: {
-    readonly current: {
-      readonly isScrolling: boolean;
-      readonly pendingJump: number;
-    };
-  };
-};
+export type ZeroVirtualizerResult<TRow> = VirtualizerSnapshot<TRow>;
 
 /**
  * Hook that creates a virtualized list with bidirectional pagination and state
  * persistence, backed by Zero's reactive queries.
  *
- * Rows are rendered in normal document flow. Native scroll anchoring is turned
- * off; instead the virtualizer keeps the viewport visually stable itself by
- * pinning a reference row and folding any above-viewport size change back into
- * the scroll offset - so loading rows, variable / dynamic heights, and estimate
- * relabels don't shift the visible content.
- *
- * @typeParam TListContextParams - The type of parameters that define the list's query context
- * @typeParam TRow - The type of row data returned from queries
- * @typeParam TStartRow - The type of data needed to anchor pagination
+ * Thin React binding over the framework-agnostic {@linkcode ZeroVirtualizer}:
+ * options and query results are pushed into the core every render (silent
+ * staging), DOM work runs from layout effects (pre-paint), and re-renders are
+ * driven by the core's change notifications.
  */
 function useZeroVirtualizerImpl<TListContextParams, TRow, TStartRow>(
-  {
-    estimateSize,
-    overscan = 5,
-    getScrollElement,
-    anchoring = 'auto',
-    getRowKey,
-
-    listContextParams,
-    count,
-    permalinkID,
-    getPageQuery,
-    getSingleQuery,
-    settleTime = 2000,
-    toStartRow,
-
-    scrollState,
-    onScrollStateChange,
-    onSettled,
-  }: UseZeroVirtualizerOptions<TListContextParams, TRow, TStartRow>,
+  options: UseZeroVirtualizerOptions<TListContextParams, TRow, TStartRow>,
   adapter: ScrollAdapter,
 ): ZeroVirtualizerResult<TRow> {
-  // Only restore from scrollState if its listContextParams matches the current
-  // context. Uses JSON.stringify since scrollState may come from serialized
-  // storage (e.g. history.state) where object identity is not preserved.
-  const effectiveScrollState = useMemo(() => {
-    if (!scrollState) return null;
-    if (
-      JSON.stringify(scrollState.listContextParams) !==
-      JSON.stringify(listContextParams)
-    ) {
-      return null;
-    }
-    return scrollState;
-  }, [scrollState, listContextParams]);
-
-  // Settled state: flips to true after settleTime ms of no scroll activity.
-  const [settled, setSettled] = useState(false);
-  const settleTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
-    undefined,
-  );
-  const resetSettleTimer = useCallback(() => {
-    setSettled(false);
-    clearTimeout(settleTimerRef.current);
-    settleTimerRef.current = setTimeout(() => setSettled(true), settleTime);
-  }, [settleTime]);
-
-  // Reset on listContextParams change and on initial mount.
-  useEffect(() => {
-    resetSettleTimer();
-    return () => clearTimeout(settleTimerRef.current);
-  }, [resetSettleTimer, listContextParams]);
-
-  const onSettledRef = useRef(onSettled);
-  onSettledRef.current = onSettled;
-  useEffect(() => {
-    if (settled) {
-      onSettledRef.current?.();
-    }
-  }, [settled]);
-
-  // Initialize paging state from scrollState directly to avoid Strict Mode double-mount rows
-  const [paging, setPaging] = useState<
-    PagingState<TListContextParams, TStartRow>
-  >(() =>
-    effectiveScrollState
-      ? restoredPagingState(effectiveScrollState, listContextParams)
-      : permalinkID
-        ? permalinkPagingState(permalinkID, listContextParams)
-        : {
-            estimatedTotal: NUM_ROWS_FOR_LOADING_SKELETON,
-            hasReachedStart: false,
-            hasReachedEnd: false,
-            queryAnchor: {anchor: TOP_ANCHOR, listContextParams},
-          },
-  );
-  const {estimatedTotal, hasReachedStart, hasReachedEnd, queryAnchor} = paging;
-
-  // Replace the paging anchor. `totalDelta` grows the estimated total in the
-  // same (atomic) update when the anchor change relabels the virtual coordinate
-  // space; the manual anchoring re-pins the reference row across the relabel,
-  // so the visible content stays put.
-  const setAnchor = useCallback((anchor: Anchor<TStartRow>, totalDelta = 0) => {
-    setPaging(s => ({
-      ...s,
-      estimatedTotal: s.estimatedTotal + totalDelta,
-      queryAnchor: {...s.queryAnchor, anchor},
-    }));
-  }, []);
-
-  const isListContextCurrent =
-    queryAnchor.listContextParams === listContextParams;
-
-  // Whether to run the manual anchoring machinery (vs. leaving it to native
-  // `overflow-anchor`). Resolved once from the `anchoring` option.
-  const manual = useMemo(
+  const [, rerender] = useReducer(() => ({}), {});
+  // One core instance per hook lifetime. The constructor is pure (no DOM /
+  // listeners / timers), so Strict Mode's double construction is harmless —
+  // and initializing paging from the persisted scroll state here avoids
+  // Strict Mode double-mounting the rows.
+  const [core] = useState(
     () =>
-      anchoring === 'manual' ||
-      (anchoring === 'auto' && detectNeedsManualAnchoring()),
-    [anchoring],
+      new ZeroVirtualizer<TListContextParams, TRow, TStartRow>(
+        options,
+        adapter,
+      ),
   );
 
-  const anchor = useMemo(() => {
-    if (isListContextCurrent) {
-      return queryAnchor.anchor;
-    }
-    return permalinkID ? createPermalinkAnchor(permalinkID) : TOP_ANCHOR;
-  }, [isListContextCurrent, queryAnchor.anchor, permalinkID]);
-
-  const [pageSize, setPageSize] = useState(MIN_PAGE_SIZE);
-
-  const {
-    rowAt,
-    rowsLength,
-    complete,
-    rowsEmpty,
-    atStart,
-    atEnd,
-    firstRowIndex,
-    permalinkNotFound,
-  } = useRows({
-    pageSize,
-    anchor,
-    settled,
-    getPageQuery,
-    getSingleQuery,
-    toStartRow,
-  });
-
-  const newEstimatedTotal = firstRowIndex + rowsLength;
-  // Effective total-row estimate (exact once both ends have been reached).
-  const effectiveEstimatedTotal =
-    count ??
-    (atEnd && atStart && complete
-      ? rowsLength
-      : Math.max(estimatedTotal, newEstimatedTotal));
-  const effectiveRowsEmpty = count === undefined ? rowsEmpty : count === 0;
-
-  // A single representative row-height estimate for the spacers. Real heights
-  // come from the DOM; this only approximates the not-yet-loaded extent (so the
-  // scrollbar is approximate, exactly as with any virtualized list).
-  const rowEstimate = Math.max(1, estimateSize(0));
-
-  // Spacer heights: the estimated pixel extent of the unloaded rows above and
-  // below the loaded window.
-  const rowsBefore = Math.max(0, firstRowIndex);
-  const rowsAfter = atEnd
-    ? 0
-    : Math.max(0, effectiveEstimatedTotal - (firstRowIndex + rowsLength));
-  const spaceBefore = atStart ? 0 : rowsBefore * rowEstimate;
-  const spaceAfter = rowsAfter * rowEstimate;
-
-  // The rows to render (the loaded window). Keyed by row id when loaded so their
-  // DOM nodes persist across paging - this is what lets scroll anchoring work.
-  const items = useMemo<VirtualRow<TRow>[]>(() => {
-    const out: VirtualRow<TRow>[] = [];
-    for (let i = firstRowIndex; i < firstRowIndex + rowsLength; i++) {
-      const row = rowAt(i);
-      out.push({
-        index: i,
-        key: row ? getRowKey(row) : defaultKeyExtractor(i),
-        row,
-      });
-    }
-    return out;
-  }, [firstRowIndex, rowsLength, rowAt, getRowKey]);
-
-  // Set to a permalink id when we navigate to a row that is NOT currently
-  // visible (a URL / deep-link jump), meaning we should scroll to it once it
-  // loads. It stays null when a permalink points at an already-visible row (e.g.
-  // clicking a visible row), so clicking a row never scrolls it. Initialized for
-  // a direct load (`/#id` with no restored scroll state).
-  const pendingPermalinkScrollRef = useRef<RowKey | null>(
-    permalinkID && !effectiveScrollState ? permalinkID : null,
+  // Silent staging — never notifies during render.
+  core.setOptions(options);
+  const {pageSize, anchor, settled} = core.getQueryInputs();
+  core.setRows(
+    useRows({
+      pageSize,
+      anchor,
+      settled,
+      getPageQuery: options.getPageQuery,
+      getSingleQuery: options.getSingleQuery,
+      toStartRow: options.toStartRow,
+    }),
   );
 
-  const scrollElRef = useRef<HTMLElement | null>(null);
-  // Bump on scroll to re-run the paging effect against fresh DOM geometry.
-  const [scrollTick, setScrollTick] = useState(0);
-  // True while a programmatic scroll (restore / permalink) has been issued but
-  // not yet observed, so paging decisions skip a beat.
-  const programmaticScrollRef = useRef(false);
-
-  // Accessors derived from the adapter's scroll element.
-  const scrollOffset = useCallback(
-    (el: HTMLElement) => adapter.scrollElement(el).scrollTop,
-    [adapter],
-  );
-  const viewportRect = useCallback(
-    (el: HTMLElement): ScrollRect => {
-      const se = adapter.scrollElement(el);
-      return {width: se.clientWidth, height: se.clientHeight};
-    },
-    [adapter],
-  );
-
-  // Scroll to an absolute offset, skipping no-op writes (same rounded offset).
-  // Returns whether it actually wrote - i.e. whether the position moved.
-  const setScrollTop = useCallback(
-    (top: number): boolean => {
-      const el = scrollElRef.current;
-      if (el && Math.round(scrollOffset(el)) !== Math.round(top)) {
-        programmaticScrollRef.current = true;
-        adapter.scrollElement(el).scrollTop = top;
-        return true;
-      }
-      return false;
-    },
-    [adapter, scrollOffset],
-  );
-
-  // ---- Manual, momentum-safe scroll anchoring --------------------------------
-  // Native overflow-anchor is disabled, so we keep the viewport visually stable
-  // ourselves. We pin one keyed "reference" row: on scroll we adopt the topmost
-  // visible row; whenever the loaded rows change size above it (a row loading, a
-  // dynamic height resolving, a spacer/estimate relabel) we measure how far it
-  // moved and put it back - the same y1−y0 correction native anchoring made.
-  //
-  // Where that correction goes depends on whether a touch scroll / momentum is in
-  // flight. Idle (incl. desktop mouse/wheel) we fold it into scrollTop. During a
-  // touch gesture we instead hold it as a margin-top on the first rendered row -
-  // writing scrollTop mid-momentum is ignored / cancels the fling on iOS, while a
-  // layout shift is fine - and reconcile margin->scrollTop atomically when the
-  // gesture ends.
-  const anchorKeyRef = useRef<RowKey | null>(null);
-  // The reference row's top offset from the viewport top, in the settled
-  // (hold-free) frame - what the anchoring keeps stable across relabels and
-  // off-screen resizes (matching native `overflow-anchor`, which anchors to the
-  // top of a visible row).
-  const anchorOffsetRef = useRef(0);
-  // True from a list reset (context change / restore / permalink) until the new
-  // data has loaded, so we don't adopt or pin a stale reference row from the
-  // outgoing list while it is being replaced.
-  const anchorSuppressedRef = useRef(false);
-  // Whether the in-flight scroll was initiated by touch. Only then do we take the
-  // momentum-safe margin-hold path - plain wheel / trackpad / programmatic scrolls
-  // (including the simulator's two-finger scroll) can safely write scrollTop.
-  const touchScrollRef = useRef(false);
-  const fingerDownRef = useRef(false);
-  const momentumGuardUntilRef = useRef(0);
-  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
-    undefined,
-  );
-  // The live anchoring state, in one ref that is also returned (read-only) as
-  // `debug`: whether a user scroll / momentum is in flight, and the scroll debt
-  // owed at the next reconcile (held meanwhile as a margin on the first row).
-  const anchorStateRef = useRef({
-    isScrolling: false,
-    pendingJump: 0,
-  });
-  // The row element currently carrying the held margin, so it can be migrated
-  // when paging swaps the first row out from under it.
-  const holdElRef = useRef<HTMLElement | null>(null);
-
-  // Apply the held correction as a margin-top on the first rendered row (px is
-  // -pendingJump: negative pulls the content up). A layout shift, not a
-  // transform - it composes with normal flow and needs no extra wrapper.
-  const applyHold = useCallback((px: number) => {
-    const el = scrollElRef.current;
-    const first = el ? firstRow(el) : null;
-    const prev = holdElRef.current;
-    if (prev && prev !== first) prev.style.marginTop = '';
-    holdElRef.current = px !== 0 ? first : null;
-    if (first) first.style.marginTop = px !== 0 ? `${px}px` : '';
-  }, []);
-
-  // If paging replaced the first row while a hold is applied, move the margin
-  // to the new first row (pre-paint, so nothing shifts visibly).
-  const migrateHold = useCallback(() => {
-    const held = holdElRef.current;
-    if (held === null) return;
-    const el = scrollElRef.current;
-    const first = el ? firstRow(el) : null;
-    if (first !== held) applyHold(-anchorStateRef.current.pendingJump);
-  }, [applyHold]);
-
-  // A row rect's top offset from the viewport top, the held margin folded out -
-  // the settled reference-row position the compensation keeps stable.
-  const anchorOffsetOf = useCallback(
-    (el: HTMLElement, rect: DOMRect) =>
-      rect.top - adapter.viewportTop(el) + anchorStateRef.current.pendingJump,
-    [adapter],
-  );
-
-  const refreshAnchor = useCallback(() => {
-    const el = scrollElRef.current;
-    if (!el) return;
-    const vTop = adapter.viewportTop(el);
-    // Top-most visible row (first whose bottom is below the viewport top), the
-    // same reference the browser's native scroll anchoring would pick.
-    let ref: HTMLElement | null = null;
-    for (const child of queryRows(el)) {
-      if (child.getBoundingClientRect().bottom > vTop + 0.5) {
-        ref = child;
-        break;
-      }
-    }
-    anchorKeyRef.current = ref?.getAttribute(VROW_KEY_ATTR) ?? null;
-    anchorOffsetRef.current = ref
-      ? anchorOffsetOf(el, ref.getBoundingClientRect())
-      : 0;
-  }, [adapter, anchorOffsetOf]);
-
-  // The single correction choke point: idle -> scrollTop; mid-gesture -> hold as
-  // the first-row margin, owed to the reconcile at gesture end.
-  const compensate = useCallback(
-    (delta: number) => {
-      const el = scrollElRef.current;
-      if (!el) return;
-      const anchorState = anchorStateRef.current;
-      if (anchorState.isScrolling && touchScrollRef.current) {
-        // Touch gesture / momentum in flight - never write scrollTop. Owe the
-        // delta to a later reconcile and hold it as the first-row margin.
-        anchorState.pendingJump += delta;
-        // Unlike the scrollTop path (which moves the settled layout back to the
-        // target), the hold leaves the reference's settled position shifted by
-        // `delta`. Re-baseline the target so we don't keep re-compensating the
-        // same growth; the owed jump is flushed at reconcile.
-        anchorOffsetRef.current += delta;
-        applyHold(-anchorState.pendingJump);
-      } else {
-        setScrollTop(scrollOffset(el) + delta);
-      }
-    },
-    [applyHold, scrollOffset, setScrollTop],
-  );
-
-  const measureAndCompensate = useCallback(() => {
-    // Stand down while another mechanism owns the scroll position: a permalink
-    // jump scrolling its target to the top, or a list-context (sort/filter)
-    // change resetting the list. Compensating against a reference row that is
-    // about to be replaced would fight those scrolls.
-    if (
-      !manual ||
-      anchorSuppressedRef.current ||
-      !isListContextCurrent ||
-      pendingPermalinkScrollRef.current !== null
-    ) {
-      return;
-    }
-    const el = scrollElRef.current;
-    if (!el) return;
-    // If paging swapped out the row carrying the held margin, re-pin it before
-    // measuring so the hold isn't double-counted as movement.
-    migrateHold();
-    // Match native scroll anchoring, which the spec suppresses at scroll offset
-    // 0: a prepend there should be *revealed* (push content down), not
-    // compensated away. Re-base to the new top row instead of pinning the old
-    // one, so a subsequent scroll off 0 stays stable. Keeps manual ~= native at
-    // the top edge (a `<= 0` also covers iOS rubber-band overscroll).
-    if (scrollOffset(el) <= 0) {
-      refreshAnchor();
-      return;
-    }
-    const key = anchorKeyRef.current;
-    const ref = key !== null ? findRow(el, key) : null;
-    if (!ref) {
-      // No valid reference yet, or it scrolled out of the loaded window - adopt
-      // the current topmost visible row.
-      refreshAnchor();
-      return;
-    }
-    const delta =
-      anchorOffsetOf(el, ref.getBoundingClientRect()) - anchorOffsetRef.current;
-    if (Math.abs(delta) < 0.5) return;
-    compensate(delta);
-  }, [
-    manual,
-    adapter,
-    anchorOffsetOf,
-    isListContextCurrent,
-    refreshAnchor,
-    compensate,
-  ]);
-
-  // Fold any owed jump into scrollTop while the margin still holds the pixels,
-  // then clear the held margin (one paint, no visible jump). Used both to
-  // reconcile at the end of a gesture and to make the geometry hold-free before
-  // an absolute scroll write (permalink / restore) that would otherwise read and
-  // write against a shifted layout.
-  const flushHold = useCallback(() => {
-    const el = scrollElRef.current;
-    const anchorState = anchorStateRef.current;
-    if (el && anchorState.pendingJump !== 0) {
-      setScrollTop(scrollOffset(el) + anchorState.pendingJump);
-      anchorState.pendingJump = 0;
-      applyHold(0);
-      return true;
-    }
-    return false;
-  }, [applyHold, scrollOffset, setScrollTop]);
-
-  // End of a scroll gesture: reconcile the held margin, re-base the anchor, and
-  // nudge paging to re-evaluate at the settled position.
-  const endScrolling = useCallback(() => {
-    if (!anchorStateRef.current.isScrolling) return;
-    anchorStateRef.current.isScrolling = false;
-    touchScrollRef.current = false;
-    fingerDownRef.current = false;
-    clearTimeout(idleTimerRef.current);
-    flushHold();
-    refreshAnchor();
-    setScrollTick(t => t + 1);
-  }, [flushHold, refreshAnchor]);
-
-  // Lift anchoring suppression once the reset list has loaded, and adopt a fresh
-  // reference from the settled list.
-  useEffect(() => {
-    if (anchorSuppressedRef.current && isListContextCurrent && complete) {
-      anchorSuppressedRef.current = false;
-      refreshAnchor();
-    }
-  }, [isListContextCurrent, complete, refreshAnchor]);
-
-  // Layout (not passive) effect so `scrollElRef` is set before the
-  // scroll-restore layout effect below runs on mount. Wires the scroll listener
-  // plus the touch / scrollend listeners that drive the is-scrolling machine.
+  // Mount/unmount: re-render subscription + listener teardown. Idempotent
+  // across Strict Mode's mount→unmount→mount (state survives detach; the
+  // per-commit effect below re-attaches).
   useLayoutEffect(() => {
-    const el = getScrollElement();
-    scrollElRef.current = el;
-    if (!el) return undefined;
-
-    // Toggle native scroll anchoring to match the resolved mode: off (so it can't
-    // fight our compensation) in manual mode, on in native mode. Set on the
-    // scroll element; spacers keep their own `overflow-anchor: none` so native
-    // mode still anchors to a real row, not a resizing spacer.
-    const anchorEl = adapter.scrollElement(el);
-    const prevAnchor = anchorEl.style.overflowAnchor;
-    anchorEl.style.overflowAnchor = manual ? 'none' : 'auto';
-
-    const scheduleIdleCheck = () => {
-      clearTimeout(idleTimerRef.current);
-      idleTimerRef.current = setTimeout(tryEndScroll, IDLE_DEBOUNCE_MS);
-    };
-    function tryEndScroll() {
-      // Never end while a finger is down or momentum may still be gliding - a
-      // scrollTop write then would cancel the fling (the classic iOS jolt).
-      if (fingerDownRef.current || Date.now() < momentumGuardUntilRef.current) {
-        scheduleIdleCheck();
-        return;
-      }
-      endScrolling();
-    }
-
-    const onScroll = () => {
-      const programmatic = programmaticScrollRef.current;
-      programmaticScrollRef.current = false;
-      // Manual anchoring only: a user / momentum scroll (not our own compensation
-      // / reconcile / restore / permalink write) marks us as scrolling - via
-      // scroll events, not only touchstart, so it also fires for trackpad / wheel
-      // / simulator scrolling that emits no touch events - and re-bases the anchor.
-      if (manual && !programmatic) {
-        anchorStateRef.current.isScrolling = true;
-        refreshAnchor();
-        if (!fingerDownRef.current) scheduleIdleCheck();
-      }
-      resetSettleTimer();
-      setScrollTick(t => t + 1);
-    };
-    const onTouchStart = () => {
-      fingerDownRef.current = true;
-      touchScrollRef.current = true;
-      anchorStateRef.current.isScrolling = true;
-      clearTimeout(idleTimerRef.current);
-    };
-    const onTouchEnd = () => {
-      fingerDownRef.current = false;
-      momentumGuardUntilRef.current = Date.now() + MOMENTUM_GUARD_MS;
-      scheduleIdleCheck();
-    };
-    const onScrollEnd = () => {
-      if (!fingerDownRef.current) endScrolling();
-    };
-
-    // scroll / scrollend attach per the adapter (they don't bubble); touch
-    // events bubble, so the scroll element hears every touch inside it. The
-    // touch / scrollend machinery only drives manual mode.
-    const unsub = adapter.subscribe(
-      el,
-      onScroll,
-      manual ? onScrollEnd : () => {},
-    );
-    const touchTarget = anchorEl;
-    if (manual) {
-      touchTarget.addEventListener('touchstart', onTouchStart, {passive: true});
-      touchTarget.addEventListener('touchend', onTouchEnd, {passive: true});
-      touchTarget.addEventListener('touchcancel', onTouchEnd, {passive: true});
-    }
+    const unsubscribe = core.subscribe(rerender);
     return () => {
-      unsub();
-      if (manual) {
-        touchTarget.removeEventListener('touchstart', onTouchStart);
-        touchTarget.removeEventListener('touchend', onTouchEnd);
-        touchTarget.removeEventListener('touchcancel', onTouchEnd);
-      }
-      clearTimeout(idleTimerRef.current);
-      anchorEl.style.overflowAnchor = prevAnchor;
+      unsubscribe();
+      core.detach();
     };
-  }, [
-    getScrollElement,
-    adapter,
-    manual,
-    refreshAnchor,
-    endScrolling,
-    resetSettleTimer,
-  ]);
+  }, [core]);
 
-  // Re-pin the reference row after every render-driven layout change (paging,
-  // anchor relabels, spacer resize) - this runs after DOM commit, before paint,
-  // so the correction is jump-free.
+  // Every commit, before paint: (re)wire the scroll element and run the
+  // core's post-DOM-update pass (anchoring compensation, restore/permalink,
+  // paging, persistence).
   useLayoutEffect(() => {
-    measureAndCompensate();
-  }, [items, spaceBefore, spaceAfter, measureAndCompensate]);
+    core.attach(options.getScrollElement());
+    core.afterDOMUpdate();
+  });
 
-  // ...and after async row resizes (dynamic heights resolving after layout). One
-  // ResizeObserver over the loaded rows; re-attached when the row set changes.
-  useLayoutEffect(() => {
-    const el = scrollElRef.current;
-    if (!manual || !el) return undefined;
-    const ro = new ResizeObserver(() => measureAndCompensate());
-    for (const child of queryRows(el)) {
-      // border-box: the row's laid-out size (what its rect reflects), so padding
-      // / border changes are caught too, not just content reflow.
-      ro.observe(child, {box: 'border-box'});
-    }
-    return () => ro.disconnect();
-  }, [manual, items, measureAndCompensate]);
-
-  // Keep page size large enough to fill the viewport ~3x.
-  useEffect(() => {
-    const el = getScrollElement();
-    const height = el ? viewportRect(el).height : 0;
-    const newPageSize =
-      height > 0
-        ? Math.max(MIN_PAGE_SIZE, makeEven(Math.ceil(height / rowEstimate) * 3))
-        : MIN_PAGE_SIZE;
-    if (newPageSize > pageSize) {
-      setPageSize(newPageSize);
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pageSize, scrollTick, getScrollElement, rowEstimate, viewportRect]);
-
-  // Persist scroll state (debounced).
-  useEffect(() => {
-    if (!isListContextCurrent || !onScrollStateChange) {
-      return;
-    }
-    const timeoutId = setTimeout(() => {
-      const el = scrollElRef.current;
-      onScrollStateChange({
-        anchor,
-        // The logical committed offset: if a gesture is mid-flight with an owed
-        // jump held in the first-row margin, fold it in so restore lands right.
-        scrollTop: el
-          ? scrollOffset(el) + anchorStateRef.current.pendingJump
-          : 0,
-        estimatedTotal: effectiveEstimatedTotal,
-        hasReachedStart,
-        hasReachedEnd,
-        listContextParams,
-      });
-    }, 100);
-    return () => clearTimeout(timeoutId);
-  }, [
-    anchor,
-    scrollTick,
-    effectiveEstimatedTotal,
-    hasReachedStart,
-    hasReachedEnd,
-    isListContextCurrent,
-    onScrollStateChange,
-    listContextParams,
-    scrollOffset,
-  ]);
-
-  useEffect(() => {
-    if (atStart) {
-      setPaging(s => (s.hasReachedStart ? s : {...s, hasReachedStart: true}));
-    }
-  }, [atStart]);
-
-  useEffect(() => {
-    if (atEnd) {
-      setPaging(s => (s.hasReachedEnd ? s : {...s, hasReachedEnd: true}));
-    }
-  }, [atEnd]);
-
-  // The estimated total is a monotonic high-water mark of the discovered
-  // extent: propose the current extent (exact when both ends are loaded) and
-  // keep the max.
-  useEffect(() => {
-    if (!complete) {
-      return;
-    }
-    const proposed = atStart && atEnd ? rowsLength : newEstimatedTotal;
-    setPaging(s =>
-      proposed > s.estimatedTotal ? {...s, estimatedTotal: proposed} : s,
-    );
-  }, [complete, atStart, atEnd, rowsLength, newEstimatedTotal]);
-
-  // Keep the anchor index non-negative and collapse phantom space at the top.
-  // Both branches relabel the virtual coordinate space, so the estimated total
-  // moves by the same offset (atomically, via `setAnchor`).
-  useEffect(() => {
-    if (rowsEmpty || !isListContextCurrent) {
-      return;
-    }
-    if (firstRowIndex < 0) {
-      const placeholderRows = !atStart ? NUM_ROWS_FOR_LOADING_SKELETON : 0;
-      const offset = -firstRowIndex + placeholderRows;
-      setAnchor({...anchor, index: anchor.index + offset}, offset);
-      return;
-    }
-    if (atStart && firstRowIndex > 0) {
-      setAnchor(TOP_ANCHOR, -firstRowIndex);
-    }
-  }, [
-    firstRowIndex,
-    anchor,
-    atStart,
-    rowsEmpty,
-    isListContextCurrent,
-    setAnchor,
-  ]);
-
-  // Starts as null (not `effectiveScrollState`) so the effect below runs on
-  // mount: the paging-state initializer restores the anchor/estimate from a
-  // persisted state, but the scroll *offset* is DOM state it can't set, so on a
-  // reload we must apply it here - otherwise the anchor is restored while
-  // scrollTop stays 0, leaving the viewport parked on the blank top spacer.
-  const appliedScrollStateRef = useRef<ScrollHistoryState<TStartRow> | null>(
-    null,
-  );
-
-  useLayoutEffect(() => {
-    const scrollStateChanged =
-      effectiveScrollState !== appliedScrollStateRef.current;
-    appliedScrollStateRef.current = effectiveScrollState;
-
-    if (isListContextCurrent && !scrollStateChanged) {
-      return;
-    }
-
-    // A list-context (sort/filter) change resets the list: drop the anchor and
-    // suppress it until the new data loads, so we don't adopt or pin a stale
-    // reference row from the outgoing list. Gated on the context change so a
-    // same-context persistence refresh (which also runs this effect ~every 100ms
-    // while scrolling) doesn't disturb the live anchor.
-    if (!isListContextCurrent) {
-      anchorKeyRef.current = null;
-      anchorSuppressedRef.current = true;
-    }
-
-    if (effectiveScrollState) {
-      // Re-base the anchor on a real restore (the write actually moves the
-      // position), but not on a same-position persist refresh which must
-      // leave the live anchor alone.
-      if (setScrollTop(effectiveScrollState.scrollTop)) {
-        anchorKeyRef.current = null;
-      }
-      setPaging(restoredPagingState(effectiveScrollState, listContextParams));
-    } else if (permalinkID) {
-      // Separate the two cases by visibility: clicking a row targets an already
-      // *visible* row, so leave the scroll alone (it's just highlighted); a URL /
-      // deep-link navigation targets an off-screen (or not-yet-loaded) row, so
-      // re-anchor on it and scroll it to the top (in the effect below).
-      const el = scrollElRef.current;
-      const targetEl = el ? findRow(el, permalinkID) : null;
-      let targetVisible = false;
-      if (el && targetEl) {
-        const vTop = adapter.viewportTop(el);
-        targetVisible = rectInViewport(
-          targetEl.getBoundingClientRect(),
-          vTop,
-          vTop + viewportRect(el).height,
-        );
-      }
-      if (!targetVisible) {
-        pendingPermalinkScrollRef.current = permalinkID;
-        if (!targetEl) {
-          // The row isn't loaded - re-anchor on it to load its page. (A loaded
-          // but off-screen row is left in place and just scrolled to.)
-          setPaging(permalinkPagingState(permalinkID, listContextParams));
-        }
-      }
-    } else {
-      anchorKeyRef.current = null;
-      setScrollTop(0);
-      setPaging({
-        estimatedTotal: 0,
-        hasReachedStart: true,
-        hasReachedEnd: false,
-        queryAnchor: {anchor: TOP_ANCHOR, listContextParams},
-      });
-    }
-  }, [
-    isListContextCurrent,
-    effectiveScrollState,
-    permalinkID,
-    listContextParams,
-    setScrollTop,
-    adapter,
-    viewportRect,
-  ]);
-
-  // When a URL / deep-link navigation targeted an off-screen permalink row (see
-  // `pendingPermalinkScrollRef`), scroll it to the top once it has rendered. We
-  // use `setScrollTop` (not `scrollIntoView`) so it sets `programmaticScrollRef`
-  // and moves the offset off zero - both are needed to stop the paging effect
-  // from re-anchoring to the top of the window while the target's context loads.
-  // The row can move as rows stream in around it, so we retry on each change
-  // until it reaches the top (or the scroll clamps because there's nothing more
-  // to scroll into, e.g. the last row).
-  useLayoutEffect(() => {
-    const pending = pendingPermalinkScrollRef.current;
-    if (pending === null) {
-      return;
-    }
-    if (pending !== permalinkID) {
-      // The permalink changed before we scrolled - drop the stale request.
-      pendingPermalinkScrollRef.current = null;
-      return;
-    }
-    const el = scrollElRef.current;
-    if (!el) return;
-    const target = findRow(el, pending);
-    if (!target) {
-      // Not rendered yet - keep the request open and retry once it loads, unless
-      // the row genuinely doesn't exist.
-      if (permalinkNotFound) {
-        pendingPermalinkScrollRef.current = null;
-      }
-      return;
-    }
-    // Commit any held margin so the target's rect and our write are relative
-    // to the real scroll offset, not a shifted layout.
-    flushHold();
-    const before = scrollOffset(el);
-    const delta = target.getBoundingClientRect().top - adapter.viewportTop(el);
-    if (Math.abs(delta) <= 1) {
-      pendingPermalinkScrollRef.current = null; // reached the top
-      return;
-    }
-    setScrollTop(before + delta);
-    // The row keeps moving as its context streams in (it may briefly be the last
-    // loaded row and clamp short of the top), so keep retrying until loading has
-    // settled. At that point it's at its final position - at the top, or as high
-    // as it can go when it's genuinely the last row - so stop.
-    if (complete) {
-      pendingPermalinkScrollRef.current = null;
-    }
-  }, [
-    permalinkID,
-    items,
-    complete,
-    permalinkNotFound,
-    setScrollTop,
-    adapter,
-    scrollOffset,
-    flushHold,
-  ]);
-
-  // ---- Paging: load more when the viewport nears the loaded window edges -----
-
-  useEffect(() => {
-    if (!isListContextCurrent || rowsEmpty || !complete) {
-      return;
-    }
-    if (programmaticScrollRef.current) {
-      return;
-    }
-    if (pendingPermalinkScrollRef.current !== null) {
-      // A permalink jump is settling: don't re-anchor to the window edge while
-      // the target's context is still loading and it's being scrolled to the top.
-      return;
-    }
-    const el = scrollElRef.current;
-    if (!el) return;
-
-    // Which loaded rows are currently visible (by data-index)? Rows are in DOM
-    // order, so once one starts below the viewport bottom the rest do too.
-    const elTop = adapter.viewportTop(el);
-    const elBottom = elTop + viewportRect(el).height;
-    let firstVisible = Infinity;
-    let lastVisible = -Infinity;
-    for (const child of queryRows(el)) {
-      const rect = child.getBoundingClientRect();
-      if (rect.top >= elBottom) break;
-      if (rectInViewport(rect, elTop, elBottom)) {
-        const idx = Number(child.getAttribute(VROW_INDEX_ATTR));
-        if (idx < firstVisible) firstVisible = idx;
-        if (idx > lastVisible) lastVisible = idx;
-      }
-    }
-    if (firstVisible === Infinity) {
-      return;
-    }
-
-    if (atStart && firstRowIndex !== 0) {
-      setAnchor(TOP_ANCHOR);
-      return;
-    }
-
-    // Both distances are 0 when the corresponding edge row is visible.
-    const threshold = Math.max(overscan, getNearPageEdgeThreshold(pageSize));
-    const distanceFromStart = firstVisible - firstRowIndex;
-    const distanceFromEnd = firstRowIndex + rowsLength - 1 - lastVisible;
-
-    const updateAnchorForEdge = (
-      targetIndex: number,
-      type: 'forward' | 'backward',
-      indexOffset: number,
-    ) => {
-      const index = toBoundIndex(targetIndex, firstRowIndex, rowsLength);
-      const startRow = rowAt(index);
-      assert(startRow !== undefined || type === 'forward');
-      setAnchor({
-        index: index + indexOffset,
-        kind: type,
-        startRow,
-      } as Anchor<TStartRow>);
-    };
-
-    if (!atStart && distanceFromStart <= threshold) {
-      updateAnchorForEdge(lastVisible + 2 * threshold, 'backward', 0);
-      return;
-    }
-    if (!atEnd && distanceFromEnd <= threshold) {
-      updateAnchorForEdge(firstVisible - 2 * threshold, 'forward', 1);
-    }
-  }, [
-    isListContextCurrent,
-    scrollTick,
-    complete,
-    pageSize,
-    firstRowIndex,
-    rowsLength,
-    atStart,
-    atEnd,
-    rowsEmpty,
-    rowAt,
-    overscan,
-    adapter,
-    viewportRect,
-    setAnchor,
-  ]);
-
-  const total =
-    count ??
-    (atStart && atEnd
-      ? rowsLength
-      : hasReachedStart && hasReachedEnd
-        ? estimatedTotal
-        : undefined);
-
-  return {
-    items,
-    spaceBefore,
-    spaceAfter,
-    rowAt,
-    complete,
-    rowsEmpty: effectiveRowsEmpty,
-    permalinkNotFound,
-    estimatedTotal: effectiveEstimatedTotal,
-    total,
-    settled,
-    debug: anchorStateRef,
-  };
+  return core.getSnapshot();
 }
 
 /**
  * Virtualized, infinitely-paginated list that scrolls inside an overflow
- * element. `getScrollElement` returns that element (which is also where the rows
- * are rendered).
+ * element. `getScrollElement` returns that element (which is also where the
+ * rows are rendered).
  *
  * @typeParam TListContextParams - The type of parameters that define the list's query context
  * @typeParam TRow - The type of row data returned from queries
@@ -1174,9 +147,9 @@ export function useZeroVirtualizer<TListContextParams, TRow, TStartRow>(
 
 /**
  * Like {@linkcode useZeroVirtualizer}, but the list scrolls the window rather
- * than an overflow element. `getScrollElement` returns the element the rows are
- * rendered into (which lives in normal page flow); the window is the scroll
- * container.
+ * than an overflow element. `getScrollElement` returns the element the rows
+ * are rendered into (which lives in normal page flow); the window is the
+ * scroll container.
  *
  * @typeParam TListContextParams - The type of parameters that define the list's query context
  * @typeParam TRow - The type of row data returned from queries
@@ -1191,30 +164,6 @@ export function useZeroWindowVirtualizer<TListContextParams, TRow, TStartRow>(
   );
 }
 
-/**
- * Clamps an index to be within the valid range of rows.
- */
-function toBoundIndex(
-  targetIndex: number,
-  firstRowIndex: number,
-  rowsLength: number,
-): number {
-  if (rowsLength === 0) {
-    return firstRowIndex;
-  }
-  return Math.max(
-    firstRowIndex,
-    Math.min(firstRowIndex + rowsLength - 1, targetIndex),
-  );
-}
-
-/**
- * Calculates the threshold for when to trigger loading more rows.
- */
-function getNearPageEdgeThreshold(pageSize: number) {
-  return Math.ceil(pageSize / 10);
-}
-
-function makeEven(n: number) {
-  return n % 2 === 0 ? n : n + 1;
-}
+// Referenced by docs above; re-exported for wrapper implementors.
+export type {VirtualizerOptions, VirtualizerSnapshot};
+export type {GetPageQuery, GetSingleQuery, RowKey};

--- a/src/react/use-zero-virtualizer.ts
+++ b/src/react/use-zero-virtualizer.ts
@@ -3,26 +3,14 @@ import {
   elementScrollAdapter,
   windowScrollAdapter,
   type ScrollAdapter,
-  type ScrollRect,
 } from '../core/scroll-adapter.ts';
-import type {GetPageQuery, GetSingleQuery, RowKey} from '../core/types.ts';
+import type {GetPageQuery, GetSingleQuery} from '../core/types.ts';
 import {
   ZeroVirtualizer,
   type VirtualizerOptions,
   type VirtualizerSnapshot,
 } from '../core/virtualizer.ts';
 import {useRows} from './use-rows.ts';
-
-// Re-exported so the public `./react` entry point is unchanged by the
-// core extraction (index.ts re-exports these from here).
-export {elementScrollAdapter, windowScrollAdapter};
-export type {ScrollAdapter, ScrollRect};
-export {rowAttributes} from '../core/dom.ts';
-export type {
-  AnchoringMode,
-  ScrollHistoryState,
-  VirtualRow,
-} from '../core/types.ts';
 
 /**
  * Options for configuring the Zero virtualizer. The core options (see
@@ -163,7 +151,3 @@ export function useZeroWindowVirtualizer<TListContextParams, TRow, TStartRow>(
     options.scrollAdapter ?? windowScrollAdapter,
   );
 }
-
-// Referenced by docs above; re-exported for wrapper implementors.
-export type {VirtualizerOptions, VirtualizerSnapshot};
-export type {GetPageQuery, GetSingleQuery, RowKey};

--- a/src/solid/create-history-scroll-state.ts
+++ b/src/solid/create-history-scroll-state.ts
@@ -1,0 +1,56 @@
+import {createMemo, createSignal, onCleanup, type Accessor} from 'solid-js';
+import {
+  getHistoryStateSnapshot,
+  subscribeHistoryState,
+  updateHistoryState,
+} from '../core/history-state.ts';
+import type {ScrollHistoryState} from '../core/types.ts';
+
+const DEFAULT_KEY = 'scrollState';
+
+/**
+ * Persists virtualizer scroll state in `window.history.state` (Solid mirror
+ * of the React `useHistoryScrollState`). The state is stored under a
+ * configurable key, so back/forward navigation restores scroll position and
+ * pagination state automatically.
+ *
+ * Call during component setup (uses `onCleanup`).
+ *
+ * @param key - The key to use in `history.state`. Defaults to `"scrollState"`.
+ * @returns `[state, setState]` to pass to `createZeroVirtualizer`'s
+ *   `scrollState` and `onScrollStateChange` options.
+ */
+export function createHistoryScrollState<TStartRow>(
+  key: string = DEFAULT_KEY,
+): [
+  Accessor<ScrollHistoryState<TStartRow> | null>,
+  (state: ScrollHistoryState<TStartRow> | null) => void,
+] {
+  const [raw, setRaw] = createSignal<unknown>(getHistoryStateSnapshot());
+  onCleanup(
+    subscribeHistoryState(() => setRaw(() => getHistoryStateSnapshot())),
+  );
+
+  // Memoized by JSON identity (matching the React hook), so an unrelated
+  // history-state change doesn't produce a new scroll-state reference.
+  const scrollState = createMemo<ScrollHistoryState<TStartRow> | null>(
+    () => {
+      const state = raw();
+      if (!state) return null;
+      return ((state as Record<string, unknown>)[key] ??
+        null) as ScrollHistoryState<TStartRow> | null;
+    },
+    null,
+    {equals: (a, b) => JSON.stringify(a) === JSON.stringify(b)},
+  );
+
+  const setScrollState = (newState: ScrollHistoryState<TStartRow> | null) => {
+    const state = getHistoryStateSnapshot();
+    updateHistoryState({
+      ...((state as Record<string, unknown>) ?? {}),
+      [key]: newState,
+    });
+  };
+
+  return [scrollState, setScrollState];
+}

--- a/src/solid/create-rows.test.ts
+++ b/src/solid/create-rows.test.ts
@@ -1,0 +1,143 @@
+import {createRoot, createSignal, type Accessor} from 'solid-js';
+import {beforeEach, describe, expect, test, vi} from 'vitest';
+import type {RowsQueryInputs} from '../core/rows.ts';
+import {createRows} from './create-rows.ts';
+
+// Fake @rocicorp/zero/solid: record each useQuery slot's accessors and hand
+// back controllable signals, so the staging logic is exercised for real.
+type Slot = {
+  querySignal: Accessor<unknown>;
+  setData: (v: unknown) => void;
+  setDetails: (v: {type: string}) => void;
+};
+const slots = vi.hoisted(() => [] as Slot[]);
+
+vi.mock('@rocicorp/zero/solid', () => ({
+  useQuery: (querySignal: Accessor<unknown>) => {
+    const [data, setData] = createSignal<unknown>(undefined);
+    const [details, setDetails] = createSignal<{type: string}>({
+      type: 'unknown',
+    });
+    slots.push({
+      querySignal,
+      setData: v => setData(() => v),
+      setDetails,
+    });
+    return [data, details];
+  },
+}));
+
+beforeEach(() => {
+  slots.length = 0;
+});
+
+type Row = {id: string};
+const toStartRow = (row: Row) => ({id: row.id});
+
+function setup(inputs: Accessor<RowsQueryInputs<{id: string}>>) {
+  const getPageQuery = vi.fn((opts: unknown) => ({
+    query: {kind: 'page', opts} as unknown,
+  }));
+  const getSingleQuery = vi.fn((opts: unknown) => ({
+    query: {kind: 'single', opts} as unknown,
+  }));
+  let rows!: ReturnType<typeof createRows<Row, {id: string}>>;
+  const dispose = createRoot(d => {
+    rows = createRows<Row, {id: string}>({
+      inputs,
+      // oxlint-disable-next-line no-explicit-any
+      getPageQuery: () => getPageQuery as any,
+      // oxlint-disable-next-line no-explicit-any
+      getSingleQuery: () => getSingleQuery as any,
+      toStartRow: () => toStartRow,
+    });
+    return d;
+  });
+  return {rows, getPageQuery, getSingleQuery, dispose};
+}
+
+describe('createRows (solid staging over the core builders)', () => {
+  test('forward anchor: main query is built (accessors invoked) and rows assemble', () => {
+    const [inputs] = createSignal<RowsQueryInputs<{id: string}>>({
+      pageSize: 4,
+      anchor: {index: 0, kind: 'forward', startRow: undefined},
+      settled: false,
+    });
+    const {rows, getPageQuery, dispose} = setup(inputs);
+
+    expect(slots).toHaveLength(3);
+    // Slot 1 (permalink single-row) stays null for a forward anchor.
+    expect(slots[0].querySignal()).toBeNull();
+    // Slot 2 carries a *built* page query — i.e. the getPageQuery accessor was
+    // invoked and its result invoked with staged options (not passed along as
+    // a function).
+    const main = slots[1].querySignal() as {kind: string; opts: unknown};
+    expect(main.kind).toBe('page');
+    expect(getPageQuery).toHaveBeenCalledWith({
+      limit: 5, // pageSize + 1 (has-more sentinel)
+      start: null,
+      dir: 'forward',
+      settled: false,
+    });
+    // Slot 3 (page-after) is permalink-only.
+    expect(slots[2].querySignal()).toBeNull();
+
+    // Feed 5 rows (pageSize + 1): window is 4 rows, more below.
+    slots[1].setData([{id: 'a'}, {id: 'b'}, {id: 'c'}, {id: 'd'}, {id: 'e'}]);
+    slots[1].setDetails({type: 'complete'});
+    const snap = rows();
+    expect(snap.rowsLength).toBe(4);
+    expect(snap.complete).toBe(true);
+    expect(snap.atStart).toBe(true);
+    expect(snap.atEnd).toBe(false);
+    expect(snap.rowAt(1)).toEqual({id: 'b'});
+    dispose();
+  });
+
+  test('permalink anchor: stages queries 2/3 on query 1 result', () => {
+    const [inputs] = createSignal<RowsQueryInputs<{id: string}>>({
+      pageSize: 4,
+      anchor: {index: 1, kind: 'permalink', id: 'x'},
+      settled: false,
+    });
+    const {rows, getSingleQuery, getPageQuery, dispose} = setup(inputs);
+
+    // Stage 1 built from the single-row lookup; stages 2/3 wait on its result.
+    const single = slots[0].querySignal() as {kind: string};
+    expect(single.kind).toBe('single');
+    expect(getSingleQuery).toHaveBeenCalledWith({id: 'x', settled: false});
+    expect(slots[1].querySignal()).toBeNull();
+    expect(slots[2].querySignal()).toBeNull();
+
+    // The single row arrives → the before/after page queries appear, anchored
+    // on the row's start data.
+    slots[0].setData({id: 'x'});
+    slots[0].setDetails({type: 'complete'});
+    expect(slots[1].querySignal()).not.toBeNull();
+    expect(slots[2].querySignal()).not.toBeNull();
+    expect(getPageQuery).toHaveBeenCalledWith({
+      limit: 3, // halfPageSize + 1
+      start: {id: 'x'},
+      dir: 'backward',
+      settled: false,
+    });
+    expect(getPageQuery).toHaveBeenCalledWith({
+      limit: 2, // halfPageSize
+      start: {id: 'x'},
+      dir: 'forward',
+      settled: false,
+    });
+
+    slots[1].setData([{id: 'w'}]);
+    slots[1].setDetails({type: 'complete'});
+    slots[2].setData([{id: 'y'}]);
+    slots[2].setDetails({type: 'complete'});
+    const snap = rows();
+    expect(snap.rowAt(1)).toEqual({id: 'x'});
+    expect(snap.rowAt(0)).toEqual({id: 'w'});
+    expect(snap.rowAt(2)).toEqual({id: 'y'});
+    expect(snap.complete).toBe(true);
+    expect(snap.firstRowIndex).toBe(0);
+    dispose();
+  });
+});

--- a/src/solid/create-rows.ts
+++ b/src/solid/create-rows.ts
@@ -1,0 +1,70 @@
+import {useQuery} from '@rocicorp/zero/solid';
+import {createMemo, type Accessor} from 'solid-js';
+import {
+  assembleRows,
+  buildAfterQuery,
+  buildMainQuery,
+  buildSingleQuery,
+  permalinkMissing,
+  type RowsQueryInputs,
+  type RowsSnapshot,
+} from '../core/rows.ts';
+import type {GetPageQuery, GetSingleQuery} from '../core/types.ts';
+
+/**
+ * Binds the virtualizer's staged queries to Zero's Solid bindings. All
+ * windowing math lives in the framework-free core ({@linkcode assembleRows});
+ * this owns only the query staging — three `useQuery` slots (queries 2 and 3
+ * depend on query 1's result for permalink anchors), each fed by an accessor
+ * so Solid re-subscribes reactively as the inputs change.
+ */
+export function createRows<TRow, TStartRow>(args: {
+  inputs: Accessor<RowsQueryInputs<TStartRow>>;
+  getPageQuery: Accessor<GetPageQuery<TRow, TStartRow>>;
+  getSingleQuery: Accessor<GetSingleQuery<TRow>>;
+  toStartRow: Accessor<(row: TRow) => TStartRow>;
+}): Accessor<RowsSnapshot<TRow>> {
+  // Stage 1: single-item lookup (permalink only; null keeps the slot stable).
+  const q1 = createMemo(() => buildSingleQuery(args.inputs(), args.getSingleQuery()));
+  const [singleRow, singleDetails] = useQuery(
+    () => q1()?.query ?? null,
+    () => q1()?.options ?? {},
+  );
+  const typedSingleRow = () => singleRow() as TRow | undefined;
+  const singleComplete = () => singleDetails().type === 'complete';
+  const notFound = () =>
+    permalinkMissing(args.inputs(), typedSingleRow(), singleComplete());
+  const singleStart = () => {
+    const row = typedSingleRow();
+    return row ? args.toStartRow()(row) : null;
+  };
+
+  // Stage 2: page-before rows (permalink) OR the main page rows.
+  const q2 = createMemo(() =>
+    buildMainQuery(args.inputs(), args.getPageQuery(), singleStart(), notFound()),
+  );
+  const [mainRows, mainDetails] = useQuery(
+    () => q2()?.query ?? null,
+    () => q2()?.options ?? {},
+  );
+
+  // Stage 3: page-after rows (permalink only).
+  const q3 = createMemo(() =>
+    buildAfterQuery(args.inputs(), args.getPageQuery(), singleStart(), notFound()),
+  );
+  const [afterRows, afterDetails] = useQuery(
+    () => q3()?.query ?? null,
+    () => q3()?.options ?? {},
+  );
+
+  return createMemo(() =>
+    assembleRows(args.inputs(), {
+      singleRow: typedSingleRow(),
+      singleComplete: singleComplete(),
+      mainRows: mainRows() as unknown as TRow[] | undefined,
+      mainComplete: mainDetails().type === 'complete',
+      afterRows: afterRows() as unknown as TRow[] | undefined,
+      afterComplete: afterDetails().type === 'complete',
+    }),
+  );
+}

--- a/src/solid/create-rows.ts
+++ b/src/solid/create-rows.ts
@@ -25,7 +25,9 @@ export function createRows<TRow, TStartRow>(args: {
   toStartRow: Accessor<(row: TRow) => TStartRow>;
 }): Accessor<RowsSnapshot<TRow>> {
   // Stage 1: single-item lookup (permalink only; null keeps the slot stable).
-  const q1 = createMemo(() => buildSingleQuery(args.inputs(), args.getSingleQuery()));
+  const q1 = createMemo(() =>
+    buildSingleQuery(args.inputs(), args.getSingleQuery()),
+  );
   const [singleRow, singleDetails] = useQuery(
     () => q1()?.query ?? null,
     () => q1()?.options ?? {},
@@ -41,7 +43,12 @@ export function createRows<TRow, TStartRow>(args: {
 
   // Stage 2: page-before rows (permalink) OR the main page rows.
   const q2 = createMemo(() =>
-    buildMainQuery(args.inputs(), args.getPageQuery(), singleStart(), notFound()),
+    buildMainQuery(
+      args.inputs(),
+      args.getPageQuery(),
+      singleStart(),
+      notFound(),
+    ),
   );
   const [mainRows, mainDetails] = useQuery(
     () => q2()?.query ?? null,
@@ -50,7 +57,12 @@ export function createRows<TRow, TStartRow>(args: {
 
   // Stage 3: page-after rows (permalink only).
   const q3 = createMemo(() =>
-    buildAfterQuery(args.inputs(), args.getPageQuery(), singleStart(), notFound()),
+    buildAfterQuery(
+      args.inputs(),
+      args.getPageQuery(),
+      singleStart(),
+      notFound(),
+    ),
   );
   const [afterRows, afterDetails] = useQuery(
     () => q3()?.query ?? null,

--- a/src/solid/create-stick-to-bottom.ts
+++ b/src/solid/create-stick-to-bottom.ts
@@ -1,0 +1,44 @@
+import {createEffect, onCleanup, type Accessor} from 'solid-js';
+import {elementScrollAdapter} from '../core/scroll-adapter.ts';
+import {
+  createStickToBottom as createController,
+  DEFAULT_STICK_SLACK,
+} from '../core/stick-to-bottom.ts';
+import type {StickOptions} from './types.ts';
+
+/**
+ * Stick-to-bottom for Solid: when content grows, keep the viewport pinned to
+ * the bottom — but only if the user was already parked there. Mirror of the
+ * React `useStickToBottom`, over the same core controller.
+ *
+ * Call during component setup (uses `onCleanup`).
+ *
+ * @param getScrollElement Returns the scroll container — the same element the
+ *   virtualizer's `getScrollElement` returns.
+ * @param dep An accessor that changes whenever the content can grow at the
+ *   bottom (e.g. the snapshot itself, or the newest row's key).
+ */
+export function createStickToBottom(
+  getScrollElement: () => HTMLElement | null,
+  dep: Accessor<unknown>,
+  options: Accessor<StickOptions> = () => ({}),
+): void {
+  let controller: ReturnType<typeof createController> | null = null;
+  onCleanup(() => controller?.detach());
+
+  createEffect(() => {
+    dep();
+    const {
+      enabled = true,
+      slack = DEFAULT_STICK_SLACK,
+      adapter = elementScrollAdapter,
+    } = options();
+    if (!enabled) {
+      controller?.detach();
+      controller = null;
+      return;
+    }
+    controller ??= createController(getScrollElement, adapter, slack);
+    controller.contentChanged();
+  });
+}

--- a/src/solid/create-stick-to-bottom.ts
+++ b/src/solid/create-stick-to-bottom.ts
@@ -24,6 +24,7 @@ export function createStickToBottom(
   options: Accessor<StickOptions> = () => ({}),
 ): void {
   let controller: ReturnType<typeof createController> | null = null;
+  let controllerKey: readonly [unknown, unknown] | null = null;
   onCleanup(() => controller?.detach());
 
   createEffect(() => {
@@ -36,9 +37,22 @@ export function createStickToBottom(
     if (!enabled) {
       controller?.detach();
       controller = null;
+      controllerKey = null;
       return;
     }
+    // Recreate when the controller's construction inputs change (they're
+    // baked into the core controller), mirroring the React binding.
+    const key = [adapter, slack] as const;
+    if (
+      controller &&
+      controllerKey &&
+      (controllerKey[0] !== key[0] || controllerKey[1] !== key[1])
+    ) {
+      controller.detach();
+      controller = null;
+    }
     controller ??= createController(getScrollElement, adapter, slack);
+    controllerKey = key;
     controller.contentChanged();
   });
 }

--- a/src/solid/create-zero-virtualizer.test.ts
+++ b/src/solid/create-zero-virtualizer.test.ts
@@ -1,0 +1,146 @@
+import {createRoot, createSignal, type Accessor} from 'solid-js';
+import {beforeEach, describe, expect, test, vi} from 'vitest';
+import type {RowsQueryInputs, RowsSnapshot} from '../core/rows.ts';
+import {
+  createZeroVirtualizer,
+  type CreateZeroVirtualizerOptions,
+} from './create-zero-virtualizer.ts';
+
+// Mock the query-staging layer (the solid twin of the React test mocking
+// use-rows.ts): the wrapper's reactive wiring runs for real against a
+// controllable rows accessor.
+const rowsMock = vi.hoisted(() => ({
+  accessor: null as Accessor<RowsSnapshot<unknown>> | null,
+  capturedInputs: null as Accessor<RowsQueryInputs<unknown>> | null,
+}));
+
+vi.mock('./create-rows.ts', () => ({
+  createRows: (args: {inputs: Accessor<RowsQueryInputs<unknown>>}) => {
+    rowsMock.capturedInputs = args.inputs;
+    return () => rowsMock.accessor!();
+  },
+}));
+
+function makeRows(
+  overrides: Partial<RowsSnapshot<unknown>>,
+): RowsSnapshot<unknown> {
+  return {
+    rowAt: () => undefined,
+    rowsLength: 0,
+    complete: false,
+    rowsEmpty: true,
+    atStart: false,
+    atEnd: false,
+    firstRowIndex: 0,
+    permalinkNotFound: false,
+    ...overrides,
+  };
+}
+
+const EST = 48;
+
+function makeOptions(
+  el: HTMLElement,
+): CreateZeroVirtualizerOptions<unknown, unknown, unknown> {
+  return {
+    estimateSize: () => EST,
+    getRowKey: row => (row as {id: string}).id,
+    listContextParams: {},
+    getScrollElement: () => el,
+    // Never reached — createRows is mocked.
+    getPageQuery: () => ({query: null as never}),
+    getSingleQuery: () => ({query: null as never}),
+    toStartRow: row => row,
+  };
+}
+
+beforeEach(() => {
+  rowsMock.accessor = null;
+  rowsMock.capturedInputs = null;
+});
+
+describe('createZeroVirtualizer (solid wrapper wiring)', () => {
+  test('renders a snapshot and reacts to row updates', () => {
+    const el = document.createElement('div');
+    const rowsData = [{id: 'a'}, {id: 'b'}, {id: 'c'}];
+    const [rows, setRows] = createSignal(
+      makeRows({
+        rowsLength: 3,
+        complete: true,
+        rowsEmpty: false,
+        atStart: true,
+        atEnd: true,
+        firstRowIndex: 0,
+        rowAt: i => rowsData[i],
+      }),
+    );
+    rowsMock.accessor = rows;
+
+    createRoot(dispose => {
+      const snap = createZeroVirtualizer(() => makeOptions(el));
+
+      expect(snap().items.map(it => it.key)).toEqual(['a', 'b', 'c']);
+      expect(snap().total).toBe(3); // atStart && atEnd → exact
+      expect(snap().spaceBefore).toBe(0);
+      expect(snap().spaceAfter).toBe(0);
+
+      // New rows flow through the reactive graph into a fresh snapshot.
+      const more = [...rowsData, {id: 'd'}];
+      setRows(
+        makeRows({
+          rowsLength: 4,
+          complete: true,
+          rowsEmpty: false,
+          atStart: true,
+          atEnd: false,
+          firstRowIndex: 0,
+          rowAt: i => more[i],
+        }),
+      );
+      expect(snap().items).toHaveLength(4);
+      expect(snap().total).toBeUndefined(); // end no longer reached
+      // The estimate is a high-water mark of the discovered extent — it never
+      // projects past the loaded rows, so the bottom spacer stays collapsed.
+      expect(snap().spaceAfter).toBe(0);
+      dispose();
+    });
+  });
+
+  test('feeds live query inputs to the rows layer', () => {
+    const el = document.createElement('div');
+    const [rows] = createSignal(makeRows({}));
+    rowsMock.accessor = rows;
+
+    createRoot(dispose => {
+      createZeroVirtualizer(() => makeOptions(el));
+      const inputs = rowsMock.capturedInputs!;
+      expect(inputs().anchor).toEqual({
+        index: 0,
+        kind: 'forward',
+        startRow: undefined,
+      });
+      expect(inputs().pageSize).toBeGreaterThanOrEqual(100);
+      expect(inputs().settled).toBe(false);
+      dispose();
+    });
+  });
+
+  test('permalink option shapes the initial query inputs', () => {
+    const el = document.createElement('div');
+    const [rows] = createSignal(makeRows({}));
+    rowsMock.accessor = rows;
+
+    createRoot(dispose => {
+      createZeroVirtualizer(() => ({
+        ...makeOptions(el),
+        permalinkID: 'row-42',
+      }));
+      expect(rowsMock.capturedInputs!().anchor).toEqual({
+        index: 1,
+        kind: 'permalink',
+        id: 'row-42',
+      });
+      dispose();
+    });
+  });
+});

--- a/src/solid/create-zero-virtualizer.ts
+++ b/src/solid/create-zero-virtualizer.ts
@@ -1,0 +1,129 @@
+import {
+  createComputed,
+  createMemo,
+  createSignal,
+  onCleanup,
+  type Accessor,
+} from 'solid-js';
+import {createEffect} from 'solid-js';
+import {
+  elementScrollAdapter,
+  windowScrollAdapter,
+  type ScrollAdapter,
+} from '../core/scroll-adapter.ts';
+import type {GetPageQuery, GetSingleQuery} from '../core/types.ts';
+import {
+  ZeroVirtualizer,
+  type VirtualizerOptions,
+  type VirtualizerSnapshot,
+} from '../core/virtualizer.ts';
+import {createRows} from './create-rows.ts';
+
+/**
+ * Options for {@linkcode createZeroVirtualizer}: the core
+ * {@linkcode VirtualizerOptions} plus the Solid-side wiring — the scroll
+ * element getter, the query functions (bound via `@rocicorp/zero/solid`),
+ * and an optional custom scroll adapter.
+ */
+export type CreateZeroVirtualizerOptions<TListContextParams, TRow, TStartRow> =
+  VirtualizerOptions<TListContextParams, TRow, TStartRow> & {
+    /** Returns the scrollable container element (a Solid ref). */
+    getScrollElement: () => HTMLElement | null;
+    /** Function that returns a query for fetching a page of rows */
+    getPageQuery: GetPageQuery<TRow, TStartRow>;
+    /** Function that returns a query for fetching a single row by ID */
+    getSingleQuery: GetSingleQuery<TRow>;
+    /** Function to extract the start row data from a full row */
+    toStartRow: (row: TRow) => TStartRow;
+    /**
+     * How the scroll container is read and driven. Defaults to
+     * {@linkcode elementScrollAdapter}; pass {@linkcode windowScrollAdapter}
+     * for a list that scrolls the window.
+     */
+    scrollAdapter?: ScrollAdapter | undefined;
+  };
+
+/**
+ * Solid binding for the Zero virtualizer: a thin reactive shell over the
+ * framework-agnostic {@linkcode ZeroVirtualizer} core (the same core the
+ * React hook uses).
+ *
+ * Returns an accessor of the current snapshot — coarse-grained on purpose
+ * (the snapshot identity only changes when content does; a fine-grained
+ * store projection can layer on top later).
+ *
+ * Call during component setup (uses `onCleanup`).
+ */
+export function createZeroVirtualizer<TListContextParams, TRow, TStartRow>(
+  options: Accessor<
+    CreateZeroVirtualizerOptions<TListContextParams, TRow, TStartRow>
+  >,
+): Accessor<VirtualizerSnapshot<TRow>> {
+  const initial = options();
+  const adapter = initial.scrollAdapter ?? elementScrollAdapter;
+  // The constructor is pure (no DOM / listeners / timers), so eager
+  // construction during setup is safe.
+  const core = new ZeroVirtualizer<TListContextParams, TRow, TStartRow>(
+    initial,
+    adapter,
+  );
+
+  // Bridge core-driven changes (scroll, timers, transitions) into Solid's
+  // reactive graph.
+  const [version, setVersion] = createSignal(0);
+  const unsubscribe = core.subscribe(() => setVersion(v => v + 1));
+  onCleanup(() => {
+    unsubscribe();
+    core.detach();
+  });
+
+  // Silent staging — createComputed runs during the render phase, before
+  // effects, mirroring the React wrapper's render-time setOptions/setRows.
+  createComputed(() => core.setOptions(options()));
+
+  const inputs = createMemo(() => {
+    version();
+    options();
+    return core.getQueryInputs();
+  });
+
+  const rows = createRows<TRow, TStartRow>({
+    inputs,
+    getPageQuery: () => options().getPageQuery,
+    getSingleQuery: () => options().getSingleQuery,
+    toStartRow: () => options().toStartRow,
+  });
+  createComputed(() => core.setRows(rows()));
+
+  // Post-DOM-update pass: Solid effects run after the DOM is patched (still
+  // pre-paint) — the `useLayoutEffect` slot of the React wrapper.
+  createEffect(() => {
+    version();
+    rows();
+    core.attach(options().getScrollElement());
+    core.afterDOMUpdate();
+  });
+
+  return createMemo(() => {
+    version();
+    rows();
+    options();
+    return core.getSnapshot();
+  });
+}
+
+/**
+ * Like {@linkcode createZeroVirtualizer}, but the list scrolls the window
+ * rather than an overflow element (`getScrollElement` returns the element the
+ * rows are rendered into; the window is the scroll container).
+ */
+export function createZeroWindowVirtualizer<TListContextParams, TRow, TStartRow>(
+  options: Accessor<
+    CreateZeroVirtualizerOptions<TListContextParams, TRow, TStartRow>
+  >,
+): Accessor<VirtualizerSnapshot<TRow>> {
+  return createZeroVirtualizer(() => ({
+    scrollAdapter: windowScrollAdapter,
+    ...options(),
+  }));
+}

--- a/src/solid/create-zero-virtualizer.ts
+++ b/src/solid/create-zero-virtualizer.ts
@@ -117,7 +117,11 @@ export function createZeroVirtualizer<TListContextParams, TRow, TStartRow>(
  * rather than an overflow element (`getScrollElement` returns the element the
  * rows are rendered into; the window is the scroll container).
  */
-export function createZeroWindowVirtualizer<TListContextParams, TRow, TStartRow>(
+export function createZeroWindowVirtualizer<
+  TListContextParams,
+  TRow,
+  TStartRow,
+>(
   options: Accessor<
     CreateZeroVirtualizerOptions<TListContextParams, TRow, TStartRow>
   >,

--- a/src/solid/index.ts
+++ b/src/solid/index.ts
@@ -1,0 +1,34 @@
+export type {
+  GetPageQuery,
+  GetPageQueryOptions,
+  GetQueryReturnType,
+  GetSingleQuery,
+  GetSingleQueryOptions,
+  QueryOptions,
+  QueryResult,
+} from '../core/types.ts';
+export {
+  elementScrollAdapter,
+  windowScrollAdapter,
+  type ScrollAdapter,
+  type ScrollRect,
+} from '../core/scroll-adapter.ts';
+export {rowAttributes} from '../core/dom.ts';
+export type {
+  AnchoringMode,
+  RowKey,
+  ScrollHistoryState,
+  VirtualRow,
+} from '../core/types.ts';
+export type {
+  VirtualizerOptions,
+  VirtualizerSnapshot,
+} from '../core/virtualizer.ts';
+export {createHistoryScrollState} from './create-history-scroll-state.ts';
+export {createStickToBottom} from './create-stick-to-bottom.ts';
+export type {StickOptions} from './types.ts';
+export {
+  createZeroVirtualizer,
+  createZeroWindowVirtualizer,
+  type CreateZeroVirtualizerOptions,
+} from './create-zero-virtualizer.ts';

--- a/src/solid/types.ts
+++ b/src/solid/types.ts
@@ -1,0 +1,10 @@
+import type {ScrollAdapter} from '../core/scroll-adapter.ts';
+
+export type StickOptions = {
+  /** Turn the behavior on/off. Defaults to `true`. */
+  enabled?: boolean | undefined;
+  /** Px of slack around the edge. */
+  slack?: number | undefined;
+  /** The same adapter the virtualizer uses (element by default). */
+  adapter?: ScrollAdapter | undefined;
+};

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -4,5 +4,9 @@
     "outDir": "../dist/",
     "noEmit": false
   },
-  "include": ["./react/index.ts"]
+  "include": [
+    "./react/index.ts",
+    "./solid/index.ts",
+    "./core/index.ts"
+  ]
 }

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -4,9 +4,5 @@
     "outDir": "../dist/",
     "noEmit": false
   },
-  "include": [
-    "./react/index.ts",
-    "./solid/index.ts",
-    "./core/index.ts"
-  ]
+  "include": ["./react/index.ts", "./solid/index.ts", "./core/index.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,11 @@
 import {defineConfig} from 'vitest/config';
 
 export default defineConfig({
+  // solid-js ships a non-reactive server build; tests need the browser build
+  // (signals/memos/effects actually propagate) — same resolution the demo gets.
+  resolve: {
+    conditions: ['browser', 'development'],
+  },
   test: {
     environment: 'happy-dom',
     include: ['src/**/*.test.{ts,tsx}'],


### PR DESCRIPTION
Stacked on #42.

Splits the virtualizer into a framework-free core with thin framework wrappers, TanStack-Virtual style, so React and SolidJS share one implementation.

## Structure

- **`src/core/`** — `ZeroVirtualizer` class owning the whole machine: paging state, scroll anchoring (native + momentum-safe manual with the first-row margin hold), settle/persist/idle timers, permalink + restore flows, and paging evaluation. Plus the staged query builders / windowing math, scroll adapters, `data-vrow-*` DOM contract, stick-to-bottom controller, and the Navigation-API history store.
- **`src/react/`** — `useZeroVirtualizer` is now ~150 lines of wiring (instance in `useState`, rerender-bump subscription, two layout effects). **Public API unchanged.**
- **`src/solid/`** — new: `createZeroVirtualizer` / `createZeroWindowVirtualizer`, `createRows` over `@rocicorp/zero/solid`, `createHistoryScrollState`, `createStickToBottom`.

## Wrapper contract

`setOptions()` / `setRows()` are silent render-safe staging; `getQueryInputs()` → `{anchor, pageSize, settled}` feeds each framework's Zero query bindings and results return via `setRows()` (the query loop TanStack doesn't have); `attach()` + `afterDOMUpdate()` run post-commit/pre-paint; re-renders via `subscribe()` with an identity-cached `getSnapshot()`.

## Notable

- `scrollTick` is gone: scroll events evaluate paging/pageSize/persistence inside the core and only notify when something observable changed — scrolling no longer forces React renders.
- Fixes a latent paging stall: a far jump (scrollbar drag, instant `scrollTop` write) that parked the viewport entirely inside a spacer could deadlock paging; the core now recovers (top re-anchor for jumps to 0, cascading from the nearer window edge otherwise).
- `./core` and `./solid` entry points added; `./core` is documented as **experimental** (breaking changes allowed while the API settles). `solid-js` is an optional peer.

## Verification

- 35/35 Playwright e2e (chromium + webkit), 21/21 unit tests (the hook's table cases now run framework-free against the core), types/lint clean.
- Touch-path probe: margin hold applied mid-gesture, migrated across paging, reconciled into `scrollTop` at gesture end. Backward-paging lockstep probe unchanged.
