### PR TITLE
fix(core): invalidate snapshot on option changes; notify settled flip on scroll

### DIFF
--- a/src/core/virtualizer.test.ts
+++ b/src/core/virtualizer.test.ts
@@ -213,6 +213,83 @@ describe('ZeroVirtualizer snapshot — items, space and total', () => {
 });
 
 describe('ZeroVirtualizer wrapper contract', () => {
+  test('changing count invalidates the cached snapshot', () => {
+    const opts = makeOptions();
+    const v = new ZeroVirtualizer(opts);
+    v.setRows(
+      makeRows({
+        rowsLength: 20,
+        complete: false,
+        rowsEmpty: false,
+        atStart: true,
+        atEnd: false,
+        firstRowIndex: 0,
+      }),
+    );
+    const a = v.getSnapshot();
+    expect(a.total).toBe(undefined);
+
+    // Same option identities → cache holds.
+    v.setOptions(opts);
+    expect(v.getSnapshot()).toBe(a);
+
+    // A live count query updating `count` must reach the next snapshot even
+    // though the rows didn't change.
+    v.setOptions({...opts, count: 42});
+    const b = v.getSnapshot();
+    expect(b).not.toBe(a);
+    expect(b.total).toBe(42);
+    expect(b.estimatedTotal).toBe(42);
+  });
+
+  test('changing estimateSize invalidates the cached snapshot', () => {
+    const rows = {
+      rowsLength: 20,
+      complete: true,
+      rowsEmpty: false,
+      atStart: false,
+      atEnd: false,
+      firstRowIndex: 5,
+    };
+    const v = makeVirtualizer(rows);
+    expect(v.getSnapshot().spaceBefore).toBe(5 * EST);
+
+    v.setOptions(makeOptions({estimateSize: () => 10}));
+    expect(v.getSnapshot().spaceBefore).toBe(5 * 10);
+  });
+
+  test('scrolling notifies the settled → false transition', () => {
+    vi.useFakeTimers();
+    try {
+      let offsetCb: ((offset: number) => void) | undefined;
+      const v = new ZeroVirtualizer(
+        makeOptions({
+          observeElementRect: () => {},
+          observeElementOffset: (_instance, cb) => {
+            offsetCb = cb;
+          },
+        }),
+      );
+      v.attach(document.createElement('div'));
+
+      // Idle for settleTime → settled.
+      vi.advanceTimersByTime(2000);
+      expect(v.getSnapshot().settled).toBe(true);
+
+      // A scroll flips settled back to false; listeners must hear about it
+      // even when nothing else (paging, page size) changed.
+      const listener = vi.fn();
+      v.subscribe(listener);
+      offsetCb!(100);
+      expect(listener).toHaveBeenCalled();
+      expect(v.getSnapshot().settled).toBe(false);
+
+      v.detach();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   test('snapshot identity is cached until state changes', () => {
     const v = makeVirtualizer({
       rowsLength: 3,

--- a/src/core/virtualizer.ts
+++ b/src/core/virtualizer.ts
@@ -341,7 +341,20 @@ export class ZeroVirtualizer<TListContextParams, TRow, TStartRow> {
   setOptions(
     options: VirtualizerOptions<TListContextParams, TRow, TStartRow>,
   ): void {
+    const prev = this.#options;
     this.#options = options;
+    // The snapshot cache is keyed on #version, so invalidate it when an
+    // option it derives from changed: `count` feeds `total`/`estimatedTotal`/
+    // `rowsEmpty`, `estimateSize` the space estimates, `getRowKey` the item
+    // keys. Still silent (no notify) — the caller is mid-render and reads
+    // the rebuilt snapshot in the same pass.
+    if (
+      prev.count !== options.count ||
+      prev.estimateSize !== options.estimateSize ||
+      prev.getRowKey !== options.getRowKey
+    ) {
+      this.#version++;
+    }
   }
 
   /** Silent rows ingestion — safe to call during render. */
@@ -423,7 +436,9 @@ export class ZeroVirtualizer<TListContextParams, TRow, TStartRow> {
         t.removeEventListener('touchcancel', this.#onTouchEnd);
       };
     }
-    this.#resetSettleTimer();
+    // Wrapped so a settled → false flip on re-attach reaches listeners (same
+    // reasoning as in #onScrollOffset).
+    this.#withNotify(() => this.#resetSettleTimer());
   }
 
   /** Remove all listeners/observers/timers. State survives (Strict Mode). */
@@ -915,8 +930,13 @@ export class ZeroVirtualizer<TListContextParams, TRow, TStartRow> {
       this.#gestureScrolled = true;
       this.#refreshAnchor();
     }
-    this.#resetSettleTimer();
-    this.#withNotify(() => this.#evaluate());
+    // Inside #withNotify so the settled → false version bump is part of the
+    // baseline diff — otherwise a scroll that changes nothing else would
+    // leave listeners rendering (and querying with) a stale `settled: true`.
+    this.#withNotify(() => {
+      this.#resetSettleTimer();
+      this.#evaluate();
+    });
   };
 
   #onScrollEnd = (): void => {


### PR DESCRIPTION
Two notification/bookkeeping holes in the core's version-counter design:

**1. `setOptions` never invalidated the snapshot cache.** `getSnapshot()` is cached solely on `#version`, but `setOptions` didn't bump it — so a change to `count` (e.g. a live Zero count query updating), `estimateSize`, or `getRowKey` kept serving the cached snapshot with stale `total` / `estimatedTotal` / `spaceAfter` until an unrelated rows or paging change happened to rebuild it. `setOptions` now compares the snapshot-relevant options and invalidates on change — still silent (no notify), so it remains render-safe; the caller reads the rebuilt snapshot in the same pass.

**2. The `settled → false` flip on scroll was never notified.** `#onScrollOffset` called `#resetSettleTimer()` (which bumps the version when flipping `settled`) *before* `#withNotify` captured its baseline, so when a scroll changed nothing else, listeners kept rendering — and issuing queries with — `settled: true` for the whole scroll. The reset now runs inside the `#withNotify` block; same fix applied to the reset in `attach()` for the re-attach-while-settled case.

Adds three unit tests: count-change invalidation (with cache-holds control), estimateSize-change invalidation, and a settle-flip notification test driven through `attach()` + a simulated scroll event.
