### PR TITLE
docs+fix(core): stop teaching inline listContextParams; warn on identity churn

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,19 @@ function toStartRow(item: Item): ItemStart {
   return {id: item.id, created: item.created};
 }
 
+// listContextParams identifies the sort/filter context the list is showing.
+// It is compared by identity (===): a new reference means "new context" and
+// resets the list (anchor and scroll position). Pass a stable reference — a
+// module constant like this, or `useMemo` when it's derived from state —
+// never an inline object literal.
+const listContextParams = {};
+
 export function ItemList() {
   const parentRef = useRef<HTMLDivElement>(null);
   const [scrollState, onScrollStateChange] = useHistoryScrollState<ItemStart>();
 
   const {items, spaceBefore, spaceAfter} = useZeroVirtualizer({
-    listContextParams: {},
+    listContextParams,
     getScrollElement: useCallback(() => parentRef.current, []),
     estimateSize: useCallback(() => 48, []),
     getRowKey,
@@ -197,13 +204,18 @@ import {
   rowAttributes,
 } from '@rocicorp/zero-virtual/solid';
 
+// Compared by identity, exactly as in React (see above): keep the reference
+// stable — a module constant, or a memo when derived from signals — since the
+// options accessor re-runs on every reactive update.
+const listContextParams = {};
+
 export function ItemList() {
   let parentRef: HTMLDivElement | undefined;
   const [scrollState, onScrollStateChange] =
     createHistoryScrollState<ItemStart>();
 
   const snapshot = createZeroVirtualizer(() => ({
-    listContextParams: {},
+    listContextParams,
     getScrollElement: () => parentRef ?? null,
     estimateSize: () => 48,
     getRowKey,

--- a/src/core/virtualizer.test.ts
+++ b/src/core/virtualizer.test.ts
@@ -293,6 +293,19 @@ describe('ZeroVirtualizer wrapper contract', () => {
     }
   });
 
+  test('identity-churn warning is best-effort for non-serializable params', () => {
+    const circularA: {self?: unknown} = {};
+    circularA.self = circularA;
+    const circularB: {self?: unknown} = {};
+    circularB.self = circularB;
+
+    const v = new ZeroVirtualizer(makeOptions({listContextParams: circularA}));
+    v.setOptions(makeOptions({listContextParams: circularB}));
+    // JSON.stringify throws on circular params; the diagnostic must not
+    // break the context-reset path.
+    expect(() => v.afterDOMUpdate()).not.toThrow();
+  });
+
   test('query inputs fall back to the new context after a context change', () => {
     const ctxA = {sort: 'a'};
     const v = new ZeroVirtualizer(makeOptions({listContextParams: ctxA}));

--- a/src/core/virtualizer.test.ts
+++ b/src/core/virtualizer.test.ts
@@ -266,6 +266,33 @@ describe('ZeroVirtualizer wrapper contract', () => {
     });
   });
 
+  test('warns once when listContextParams churns identity without content', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const v = new ZeroVirtualizer(
+        makeOptions({listContextParams: {sort: 'a'}}),
+      );
+
+      // A real context change (different content) never warns.
+      v.setOptions(makeOptions({listContextParams: {sort: 'b'}}));
+      v.afterDOMUpdate();
+      expect(warn).not.toHaveBeenCalled();
+
+      // The un-memoized inline-literal bug: fresh identity, same content —
+      // warn once, not per commit.
+      v.setOptions(makeOptions({listContextParams: {sort: 'b'}}));
+      v.afterDOMUpdate();
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0][0]).toMatch(/listContextParams/);
+
+      v.setOptions(makeOptions({listContextParams: {sort: 'b'}}));
+      v.afterDOMUpdate();
+      expect(warn).toHaveBeenCalledTimes(1);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   test('query inputs fall back to the new context after a context change', () => {
     const ctxA = {sort: 'a'};
     const v = new ZeroVirtualizer(makeOptions({listContextParams: ctxA}));

--- a/src/core/virtualizer.ts
+++ b/src/core/virtualizer.ts
@@ -1047,14 +1047,29 @@ export class ZeroVirtualizer<TListContextParams, TRow, TStartRow> {
     if (this.#warnedListContextChurn) return;
     const prev = this.#paging.queryAnchor.listContextParams;
     const next = this.#options.listContextParams;
-    if (JSON.stringify(prev) === JSON.stringify(next)) {
+
+    let prevJSON: string | undefined;
+    let nextJSON: string | undefined;
+    try {
+      prevJSON = JSON.stringify(prev);
+      nextJSON = JSON.stringify(next);
+    } catch {
+      return;
+    }
+
+    // If either side can't be represented in JSON, don't attempt this heuristic.
+    if (prevJSON === undefined || nextJSON === undefined) return;
+
+    if (prevJSON === nextJSON) {
       this.#warnedListContextChurn = true;
-      console.warn(
-        'zero-virtual: listContextParams changed identity without changing ' +
-          'content. It is compared by identity (===) and every change ' +
-          'resets the list, so pass a stable reference (a module constant ' +
-          'or a memo) instead of recreating the object each render.',
-      );
+      if (typeof console !== 'undefined') {
+        console.warn(
+          'zero-virtual: listContextParams changed identity without changing ' +
+            'content. It is compared by identity (===) and every change ' +
+            'resets the list, so pass a stable reference (a module constant ' +
+            'or a memo) instead of recreating the object each render.',
+        );
+      }
     }
   }
 

--- a/src/core/virtualizer.ts
+++ b/src/core/virtualizer.ts
@@ -308,6 +308,8 @@ export class ZeroVirtualizer<TListContextParams, TRow, TStartRow> {
   #lastPersistKey = '';
   // Settle-timer reset on list-context change (the old effect's dep).
   #lastSettleContext: TListContextParams;
+  // One-shot guard for the identity-churn warning below.
+  #warnedListContextChurn = false;
 
   constructor(
     options: VirtualizerOptions<TListContextParams, TRow, TStartRow>,
@@ -1035,6 +1037,27 @@ export class ZeroVirtualizer<TListContextParams, TRow, TStartRow> {
     }
   }
 
+  // listContextParams is compared by identity: a new reference means "new
+  // context" and resets the list. A reference that changed while its content
+  // did not is the signature of an un-memoized inline literal (e.g.
+  // `listContextParams: {}` recreated every render) — the reset then fires on
+  // every commit and pagination can never advance. Warn once so the bug is
+  // diagnosable instead of just "the list keeps jumping to the top".
+  #warnOnListContextIdentityChurn(): void {
+    if (this.#warnedListContextChurn) return;
+    const prev = this.#paging.queryAnchor.listContextParams;
+    const next = this.#options.listContextParams;
+    if (JSON.stringify(prev) === JSON.stringify(next)) {
+      this.#warnedListContextChurn = true;
+      console.warn(
+        'zero-virtual: listContextParams changed identity without changing ' +
+          'content. It is compared by identity (===) and every change ' +
+          'resets the list, so pass a stable reference (a module constant ' +
+          'or a memo) instead of recreating the object each render.',
+      );
+    }
+  }
+
   // The restore / context-reset / permalink-navigation block. Runs only when
   // its inputs changed (the old effect's dependency semantics): a new
   // persisted state, a new permalinkID, or a context mismatch.
@@ -1058,6 +1081,7 @@ export class ZeroVirtualizer<TListContextParams, TRow, TStartRow> {
     // suppress it until the new data loads, so we don't adopt or pin a stale
     // reference row from the outgoing list.
     if (!this.#isListContextCurrent()) {
+      this.#warnOnListContextIdentityChurn();
       this.#anchorKey = null;
       this.#anchorSuppressed = true;
     }


### PR DESCRIPTION
`listContextParams` is compared by identity (`===`), and every identity change resets the list (anchor dropped, scroll position reset). The README quick-starts passed an inline `{}` literal — recreated on every render/reactive update — so with that pattern each re-render registers as a context change, the reset fires every commit, and pagination can never advance past the first window. The demos already memoize (`demo/react/list-shared.ts`, `demo/solid/list-shared.ts`); the README taught the broken pattern.

Changes:

- **README:** both quick-starts hoist `listContextParams` to a module constant and document the identity contract (React: module constant or `useMemo`; Solid: module constant or a memo, since the options accessor re-runs on every reactive update).
- **Core:** warn once when the tell-tale signature of the bug is detected — identity changed while the JSON content is identical — so apps that hit it get a diagnosis instead of a list that keeps yanking to the top. Legitimate context changes (different content) never warn.

Adds a unit test covering real-change (no warn), churn (warn once), and repeat churn (still once).