### PR TITLE
fix(react): useHistoryScrollState setter re-reads live history state

### DIFF
--- a/src/react/use-history-scroll-state.test.ts
+++ b/src/react/use-history-scroll-state.test.ts
@@ -1,0 +1,83 @@
+import {act, renderHook} from '@testing-library/react';
+import {afterEach, beforeEach, expect, test} from 'vitest';
+import type {ScrollHistoryState} from '../core/types.ts';
+import {useHistoryScrollState} from './use-history-scroll-state.ts';
+
+// Minimal Navigation API stub (happy-dom doesn't implement it): current-entry
+// state plus currententrychange, which is all core/history-state.ts uses.
+function installNavigationStub(): () => void {
+  let state: unknown;
+  const listeners = new Set<() => void>();
+  const stub = {
+    currentEntry: {
+      getState: () => state,
+    },
+    updateCurrentEntry({state: next}: {state: unknown}) {
+      // The real API structured-clones; a JSON round-trip is close enough
+      // for the plain data this module stores.
+      state = next === undefined ? undefined : JSON.parse(JSON.stringify(next));
+      for (const listener of listeners) listener();
+    },
+    addEventListener(_type: string, listener: () => void) {
+      listeners.add(listener);
+    },
+    removeEventListener(_type: string, listener: () => void) {
+      listeners.delete(listener);
+    },
+  };
+  const g = globalThis as {navigation?: unknown};
+  g.navigation = stub;
+  return () => {
+    delete g.navigation;
+  };
+}
+
+let uninstall: () => void;
+beforeEach(() => {
+  uninstall = installNavigationStub();
+});
+afterEach(() => uninstall());
+
+function fakeScrollState(scrollTop: number): ScrollHistoryState<unknown> {
+  return {
+    anchor: {index: 0, kind: 'forward', startRow: undefined},
+    scrollTop,
+    estimatedTotal: 100,
+    hasReachedStart: true,
+    hasReachedEnd: false,
+    listContextParams: {},
+  };
+}
+
+test('missing key reads as null', () => {
+  const {result} = renderHook(() => useHistoryScrollState('a'));
+  expect(result.current[0]).toBeNull();
+});
+
+test('round-trips state under its key', () => {
+  const {result} = renderHook(() => useHistoryScrollState('a'));
+  const s = fakeScrollState(123);
+  act(() => result.current[1](s));
+  expect(result.current[0]).toEqual(s);
+});
+
+test('a debounced write does not clobber sibling keys', () => {
+  const {result} = renderHook(() => ({
+    a: useHistoryScrollState('a'),
+    b: useHistoryScrollState('b'),
+  }));
+
+  // The virtualizer holds onScrollStateChange callbacks and invokes them from
+  // a persist debounce, so both of these closures predate either write —
+  // exactly the two-virtualizers-on-one-page timing.
+  const setA = result.current.a[1];
+  const setB = result.current.b[1];
+
+  const stateA = fakeScrollState(1);
+  const stateB = fakeScrollState(2);
+  act(() => setA(stateA));
+  act(() => setB(stateB));
+
+  expect(result.current.a[0]).toEqual(stateA);
+  expect(result.current.b[0]).toEqual(stateB);
+});

--- a/src/react/use-history-scroll-state.test.ts
+++ b/src/react/use-history-scroll-state.test.ts
@@ -1,5 +1,5 @@
 import {act, renderHook} from '@testing-library/react';
-import {afterEach, beforeEach, expect, test} from 'vitest';
+import {beforeEach, expect, test} from 'vitest';
 import type {ScrollHistoryState} from '../core/types.ts';
 import {useHistoryScrollState} from './use-history-scroll-state.ts';
 
@@ -13,9 +13,8 @@ function installNavigationStub(): () => void {
       getState: () => state,
     },
     updateCurrentEntry({state: next}: {state: unknown}) {
-      // The real API structured-clones; a JSON round-trip is close enough
-      // for the plain data this module stores.
-      state = next === undefined ? undefined : JSON.parse(JSON.stringify(next));
+      // The real API structured-clones the state.
+      state = structuredClone(next);
       for (const listener of listeners) listener();
     },
     addEventListener(_type: string, listener: () => void) {
@@ -32,11 +31,8 @@ function installNavigationStub(): () => void {
   };
 }
 
-let uninstall: () => void;
-beforeEach(() => {
-  uninstall = installNavigationStub();
-});
-afterEach(() => uninstall());
+// The returned uninstaller doubles as the per-test cleanup.
+beforeEach(() => installNavigationStub());
 
 function fakeScrollState(scrollTop: number): ScrollHistoryState<unknown> {
   return {
@@ -52,6 +48,18 @@ function fakeScrollState(scrollTop: number): ScrollHistoryState<unknown> {
 test('missing key reads as null', () => {
   const {result} = renderHook(() => useHistoryScrollState('a'));
   expect(result.current[0]).toBeNull();
+});
+
+test('missing key in an existing state object reads as null', () => {
+  const {result} = renderHook(() => ({
+    a: useHistoryScrollState('a'),
+    b: useHistoryScrollState('b'),
+  }));
+
+  // history.state is now a non-empty object — key 'a' is simply absent.
+  act(() => result.current.b[1](fakeScrollState(9)));
+
+  expect(result.current.a[0]).toBeNull();
 });
 
 test('round-trips state under its key', () => {

--- a/src/react/use-history-scroll-state.ts
+++ b/src/react/use-history-scroll-state.ts
@@ -54,7 +54,7 @@ export function useHistoryScrollState<TStartRow>(
       // Solid binding.)
       const current = getHistoryStateSnapshot();
       setState({
-        ...((current as Record<string, unknown>) ?? {}),
+        ...(current as Record<string, unknown>),
         [key]: newState,
       });
     },

--- a/src/react/use-history-scroll-state.ts
+++ b/src/react/use-history-scroll-state.ts
@@ -1,4 +1,5 @@
 import {useCallback, useMemo} from 'react';
+import {getHistoryStateSnapshot} from '../core/history-state.ts';
 import {useHistoryState} from './use-history-state.ts';
 import type {ScrollHistoryState} from '../core/types.ts';
 
@@ -39,19 +40,25 @@ export function useHistoryScrollState<TStartRow>(
 
   const scrollState: ScrollHistoryState<TStartRow> | null = useMemo(() => {
     if (!state) return null;
-    return (state as Record<string, unknown>)[
-      key
-    ] as ScrollHistoryState<TStartRow> | null;
+    return ((state as Record<string, unknown>)[key] ??
+      null) as ScrollHistoryState<TStartRow> | null;
   }, [state && JSON.stringify((state as Record<string, unknown>)[key])]);
 
   const setScrollState = useCallback(
     (newState: ScrollHistoryState<TStartRow> | null) => {
+      // Re-read the live history state instead of spreading the render-time
+      // snapshot: the virtualizer calls this from a ~100ms persist debounce,
+      // so another virtualizer (under a different key) or the app itself may
+      // have written a sibling key since this closure was created — spreading
+      // the stale snapshot would silently erase that write. (Mirrors the
+      // Solid binding.)
+      const current = getHistoryStateSnapshot();
       setState({
-        ...(state ?? {}),
+        ...((current as Record<string, unknown>) ?? {}),
         [key]: newState,
       });
     },
-    [state, key],
+    [setState, key],
   );
 
   return [scrollState, setScrollState];


### PR DESCRIPTION
The setter spread the history-state snapshot captured at render time. The virtualizer invokes `onScrollStateChange` from a ~100ms persist debounce, so with two virtualizers on one page (the documented use of the `key` parameter) — or any app-owned keys in `history.state` — a debounced write could spread a snapshot that predates a sibling key's write and silently erase it, breaking that list's back/forward restore. The Solid twin was already immune (it re-reads the snapshot inside the setter).

Changes:

- The setter re-reads `getHistoryStateSnapshot()` at call time instead of closing over the render-time `state`, mirroring the Solid binding.
- A missing key now reads as `null` (matching the declared return type) instead of `undefined`.

Adds `use-history-scroll-state.test.ts` with a minimal Navigation API stub: null read for a missing key, round-trip under a key, and the two-keys clobber timing. The clobber test fails against the previous implementation and passes with the fix.
