### PR TITLE
chore: packaging hygiene + publish-workflow gate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,16 +27,33 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
+      # Pinned: this runs with publish credentials in scope (OIDC id-token),
+      # so an unpinned npm@latest would execute an unreviewed release at the
+      # most privileged moment. 11.5.1 is the trusted-publishing minimum.
       - name: Upgrade npm for OIDC trusted publishing support
-        run: COREPACK_ENABLE_STRICT=0 npm install --global npm@latest
+        run: COREPACK_ENABLE_STRICT=0 npm install --global npm@11.5.1
 
       - name: Print tool versions
         run: |
           pnpm --version
           npm --version
 
+      - name: Verify tag matches package.json version
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          if [ "$GITHUB_REF_NAME" != "v$version" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match package.json version v$version" >&2
+            exit 1
+          fi
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Check types
+        run: pnpm run check-types
+
+      - name: Test
+        run: pnpm test
 
       - name: Build package
         run: pnpm run build

--- a/package.json
+++ b/package.json
@@ -16,10 +16,11 @@
   "files": [
     "dist/",
     "src/**/*.ts",
+    "!src/**/*.test.ts",
     "!*.tsbuildinfo"
   ],
   "type": "module",
-  "main": "index.js",
+  "sideEffects": false,
   "exports": {
     "./react": {
       "types": "./dist/react/index.d.ts",
@@ -45,9 +46,6 @@
     "test": "vitest run",
     "prepack": "rm -rf dist && pnpm run build"
   },
-  "dependencies": {
-    "@types/dom-navigation": "^1.0.7"
-  },
   "devDependencies": {
     "@rocicorp/zero": "1.7.0",
     "@testing-library/react": "^16.3.2",
@@ -65,7 +63,7 @@
     "vitest": "^4.1.2"
   },
   "peerDependencies": {
-    "@rocicorp/zero": "1.7.0",
+    "@rocicorp/zero": "^1.7.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "solid-js": "^1.9.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      '@types/dom-navigation':
-        specifier: ^1.0.7
-        version: 1.0.7
     devDependencies:
       '@rocicorp/zero':
         specifier: 1.7.0
@@ -1501,9 +1497,6 @@ packages:
 
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
-
-  '@types/dom-navigation@1.0.7':
-    resolution: {integrity: sha512-Di4W+i2faYquHUnyWUg3bBQp5pTNvjDDA7mIYfD/1WlLgan6sKkeVjGbdL78K0CuNEk5Pfc/c0rfelwkz10mnQ==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -4433,8 +4426,6 @@ snapshots:
       '@types/node': 25.5.0
 
   '@types/deep-eql@4.0.2': {}
-
-  '@types/dom-navigation@1.0.7': {}
 
   '@types/estree@1.0.8': {}
 


### PR DESCRIPTION
**package.json:**

- `peerDependencies`: `@rocicorp/zero` `1.7.0` → `^1.7.0`. The exact pin made every zero patch release an install failure (npm `ERESOLVE`) for consumers; minors are compatible, so allow the full 1.x range. (The devDependency stays pinned at exactly 1.7.0 — that's what the lockfile builds and tests against.)
- Remove `"main": "index.js"` — no such file is built or shipped, and with no `"."` entry in `exports` it only misleads legacy resolvers.
- Remove `@types/dom-navigation` from `dependencies`: types-only, referenced nowhere, and `tsconfig-shared.json` sets `"types": []` so it isn't used even by this repo's own type-check — every installer downloaded it for nothing. Lockfile updated.
- Exclude `*.test.ts` from the published tarball; add `sideEffects: false` for bundler tree-shaking.

**publish.yml:**

- Verify the pushed tag matches `package.json`'s version before anything else, so a mistyped tag can't ship an arbitrary version.
- Run `check-types` and the unit tests before publishing (previously the only gate was a successful build).
- Pin the npm upgrade to `11.5.1` (the trusted-publishing minimum) instead of `npm@latest`, which executed unreviewed code at the most privileged moment of the pipeline (OIDC id-token in scope).

Verified with a full `pnpm pack`: tarball contains `dist/` + `src/` with zero test files, and build + tests pass with the dependency removed.
