### PR TITLE
docs: Navigation API requirement (Firefox 147+) for the history-state helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ Features:
   the native `scrollend` event, which the manual anchoring relies on to
   reconcile momentum-time corrections at the end of a touch gesture (there is
   deliberately no timer-based fallback for older engines).
+- The provided history-state helpers (`useHistoryScrollState` /
+  `createHistoryScrollState`) additionally rely on the
+  [Navigation API](https://developer.mozilla.org/en-US/docs/Web/API/Navigation_API),
+  which needs **Firefox 147+** (the Chromium and Safari floors above already
+  include it). Older Firefox runs the rest of the library fine — just wire
+  `scrollState` / `onScrollStateChange` to a persistence mechanism of your
+  own (e.g. `history.replaceState` or `sessionStorage`) instead of using the
+  helpers.
 - In `native` anchoring mode, relies on the browser's CSS `overflow-anchor`
   (Chromium and Firefox; Safari implements it but doesn't enable it by default
   as of July 2026). The default `auto` mode feature-detects and falls back to
@@ -390,6 +398,14 @@ const [scrollState, onScrollStateChange] =
 
 The Solid mirror is `createHistoryScrollState` — same key parameter, with the
 state returned as an accessor.
+
+Both helpers are built on the Navigation API
+(`navigation.updateCurrentEntry`), which requires **Firefox 147+**; every
+Chromium and Safari version this library supports already has it. On older
+Firefox they throw at first use, but nothing else in the library depends on
+them: `scrollState` / `onScrollStateChange` accept any implementation, so you
+can persist the state through `history.replaceState`, `sessionStorage`, a
+router's location state, or anything else that survives navigation.
 
 For a complete working example including sorting, permalinks, and scroll-position persistence, see [demo/react/App.tsx](demo/react/App.tsx) — or its Solid twin, [demo/solid/App.tsx](demo/solid/App.tsx).
 

--- a/src/core/history-state.ts
+++ b/src/core/history-state.ts
@@ -2,6 +2,10 @@
  * A framework-free external store over the Navigation API's current-entry
  * state: subscribe / snapshot / update. The React wrapper bridges it with
  * `useSyncExternalStore`; the Solid wrapper with a signal.
+ *
+ * The Navigation API needs Firefox 147+ (all supported Chromium and Safari
+ * versions have it) — see the history-state helpers' docs for the fallback
+ * story on older Firefox.
  */
 
 let currentSnapshot: unknown = null;

--- a/src/react/use-history-scroll-state.ts
+++ b/src/react/use-history-scroll-state.ts
@@ -12,6 +12,12 @@ const DEFAULT_KEY = 'scrollState';
  * `history.state`, so back/forward navigation restores scroll position
  * and pagination state automatically.
  *
+ * Built on the Navigation API, which requires Firefox 147+ (all supported
+ * Chromium and Safari versions have it). On older Firefox, skip this helper
+ * and wire `scrollState` / `onScrollStateChange` to a persistence mechanism
+ * of your own (e.g. `history.replaceState` or `sessionStorage`) — the
+ * options accept any implementation.
+ *
  * @typeParam TStartRow - The type of data needed to anchor pagination
  * @param key - The key to use in `history.state`. Defaults to `"scrollState"`.
  *   Use different keys if you have multiple virtualizers on the same page.

--- a/src/solid/create-history-scroll-state.ts
+++ b/src/solid/create-history-scroll-state.ts
@@ -14,6 +14,12 @@ const DEFAULT_KEY = 'scrollState';
  * configurable key, so back/forward navigation restores scroll position and
  * pagination state automatically.
  *
+ * Built on the Navigation API, which requires Firefox 147+ (all supported
+ * Chromium and Safari versions have it). On older Firefox, skip this helper
+ * and wire `scrollState` / `onScrollStateChange` to a persistence mechanism
+ * of your own (e.g. `history.replaceState` or `sessionStorage`) — the
+ * options accept any implementation.
+ *
  * Call during component setup (uses `onCleanup`).
  *
  * @param key - The key to use in `history.state`. Defaults to `"scrollState"`.

--- a/src/solid/create-history-scroll-state.ts
+++ b/src/solid/create-history-scroll-state.ts
@@ -53,7 +53,7 @@ export function createHistoryScrollState<TStartRow>(
   const setScrollState = (newState: ScrollHistoryState<TStartRow> | null) => {
     const state = getHistoryStateSnapshot();
     updateHistoryState({
-      ...((state as Record<string, unknown>) ?? {}),
+      ...(state as Record<string, unknown>),
       // Zero's Solid useQuery hands out store proxies, and the anchor's start
       // row is taken straight from a query row — so the state can contain a
       // proxy, which the Navigation API's structured clone rejects. Round-trip


### PR DESCRIPTION
`useHistoryScrollState` / `createHistoryScrollState` are built on the Navigation API, which Firefox shipped in 147 — later than the library's general Firefox 109+ floor (the Chromium 114+ and Safari 26+ floors already include it).

Documents this in:

- the README **Restrictions** section (new bullet under the browser-support floor),
- the README `useHistoryScrollState` section (with the fallback story),
- the JSDoc of both helpers and the core history-state store.

On older Firefox the rest of the library works unchanged — `scrollState` / `onScrollStateChange` accept any implementation, so state can be persisted through `history.replaceState`, `sessionStorage`, a router's location state, etc. in place of the provided helpers.

Docs only; no behavior change.
