### PR TITLE
fix(core): apply scroll restore when the container attaches on a late…

### DIFF
--- a/src/core/virtualizer.dom.test.ts
+++ b/src/core/virtualizer.dom.test.ts
@@ -1,8 +1,8 @@
-import {afterEach, describe, expect, test} from 'vitest';
+import {afterEach, describe, expect, test, vi} from 'vitest';
 import {assembleRows, type RowsQueryInputs} from './rows.ts';
 import {VROW_INDEX_ATTR, VROW_KEY_ATTR} from './dom.ts';
 import {ZeroVirtualizer, type VirtualizerOptions} from './virtualizer.ts';
-import type {Anchor} from './types.ts';
+import type {Anchor, ScrollHistoryState} from './types.ts';
 
 type TestRow = {id: string};
 
@@ -208,6 +208,15 @@ function createHarness({
     deliverScroll();
   };
 
+  // A commit before the scroll container is mounted: rows are staged but the
+  // element isn't attached yet (a host that renders its scroll container
+  // lazily — e.g. after measuring available space — attaches on a later tick).
+  const tickDetached = () => {
+    core.setRows(answerQueries(core.getQueryInputs()));
+    core.attach(null);
+    core.afterDOMUpdate();
+  };
+
   const settle = (maxTicks = 20) => {
     for (let i = 0; i < maxTicks; i++) {
       const before = JSON.stringify(core.getQueryInputs().anchor);
@@ -235,6 +244,7 @@ function createHarness({
     scroller,
     wrapper,
     tick,
+    tickDetached,
     settle,
     userScroll,
     deliverScroll,
@@ -432,5 +442,67 @@ describe('manual scroll anchoring against a real (fake-geometry) container', () 
 
     expect(h.scroller.scrollTop).toBe(1000);
     expect(h.rowTop('r50')).toBe(0);
+  });
+});
+
+describe('scroll-state restore when the container mounts lazily', () => {
+  const savedState = (scrollTop: number): ScrollHistoryState<TestRow> => ({
+    anchor: {kind: 'forward', index: 0},
+    scrollTop,
+    estimatedTotal: 100,
+    hasReachedStart: true,
+    hasReachedEnd: false,
+    listContextParams: 'ctx',
+  });
+
+  test('restores the saved scrollTop when the element attaches on a later commit', () => {
+    const h = harness({
+      rowCount: 100,
+      options: {scrollState: savedState(300)},
+    });
+
+    // The host renders (and thus attaches) the scroll container only after a
+    // couple of commits — e.g. once it has measured available space.
+    h.tickDetached();
+    h.tickDetached();
+    // Nothing to restore against yet: no element, no scroll applied.
+    expect(h.scroller.scrollTop).toBe(0);
+
+    // The container mounts and attaches; the restore must now actually run
+    // rather than treat the (never-performed) detached restore as done.
+    h.settle();
+    expect(h.scroller.scrollTop).toBe(300);
+  });
+
+  test('does not persist a spurious scrollTop:0 while detached, clobbering the saved position', () => {
+    vi.useFakeTimers();
+    try {
+      const persisted: Array<ScrollHistoryState<TestRow>> = [];
+      const h = harness({
+        rowCount: 100,
+        options: {
+          scrollState: savedState(300),
+          onScrollStateChange: s =>
+            persisted.push(s as ScrollHistoryState<TestRow>),
+        },
+      });
+
+      h.tickDetached();
+      h.tickDetached();
+      // Fire any pending persist debounce: nothing should have been written
+      // while detached (a write here would be a scrollTop:0 over the saved 300).
+      vi.advanceTimersByTime(1000);
+      expect(persisted).toEqual([]);
+
+      h.settle();
+      vi.advanceTimersByTime(1000);
+      // Once attached, the restored position is persisted — and never a
+      // spurious 0.
+      expect(persisted.length).toBeGreaterThan(0);
+      expect(persisted.map(s => s.scrollTop)).not.toContain(0);
+      expect(h.scroller.scrollTop).toBe(300);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/core/virtualizer.ts
+++ b/src/core/virtualizer.ts
@@ -1101,6 +1101,19 @@ export class ZeroVirtualizer<TListContextParams, TRow, TStartRow> {
     const {permalinkID, listContextParams} = this.#options;
     const scrollStateChanged = eff !== this.#appliedScrollState;
     const permalinkChanged = permalinkID !== this.#appliedPermalinkID;
+
+    // Restoring a scroll position or resolving a permalink both need the scroll
+    // element attached — to write scrollTop, or to locate the target row. If it
+    // isn't attached yet (a host that mounts its scroll container lazily, e.g.
+    // after measuring available space, attaches it on a later commit), defer
+    // *without* recording this state as applied: otherwise the write silently
+    // no-ops against the missing element, yet the state counts as applied, so
+    // the commit that finally attaches skips the restore as already done. Bail
+    // instead, so that later commit actually performs it.
+    if ((eff || permalinkID) && !this.#el) {
+      return;
+    }
+
     this.#appliedScrollState = eff;
     this.#appliedPermalinkID = permalinkID;
 
@@ -1351,7 +1364,15 @@ export class ZeroVirtualizer<TListContextParams, TRow, TStartRow> {
 
   #schedulePersist(key = this.#persistKey()): void {
     const {onScrollStateChange} = this.#options;
-    if (!this.#isListContextCurrent() || !onScrollStateChange) return;
+    // With no attached scroll element there is no live scroll position to
+    // persist. Skip without recording the key, so the persist still fires once
+    // the container attaches. Persisting here would write a spurious
+    // scrollTop: 0 over a saved position during the window before a
+    // lazily-mounted container attaches — the exact value restore is trying to
+    // bring back.
+    if (!this.#el || !this.#isListContextCurrent() || !onScrollStateChange) {
+      return;
+    }
     this.#lastPersistKey = key;
     // Capture at schedule time (matches the old effect's closure semantics).
     const anchor = this.#paging.queryAnchor.anchor;
@@ -1361,14 +1382,15 @@ export class ZeroVirtualizer<TListContextParams, TRow, TStartRow> {
     clearTimeout(this.#persistTimer);
     this.#persistTimer = setTimeout(() => {
       const el = this.#el;
+      // The element can detach during the debounce (unmount). Skip rather than
+      // persist a spurious scrollTop: 0 over the saved position.
+      if (!el) return;
       onScrollStateChange({
         anchor,
         // The logical committed offset: if a gesture is mid-flight with an
         // owed jump held in the wrapper margin, fold it in so restore lands
         // right.
-        scrollTop: el
-          ? this.#scrollOffset(el) + this.#anchorState.pendingJump
-          : 0,
+        scrollTop: this.#scrollOffset(el) + this.#anchorState.pendingJump,
         estimatedTotal,
         hasReachedStart,
         hasReachedEnd,


### PR DESCRIPTION
…r commit

`#restoreOrReset` marked scroll state applied even when `#setScrollTop` no-oped against a still-null `#el`, so hosts that mount their scroll container lazily lost the restore — the first commit consumed it while detached, the attaching commit skipped it as done. The persist path also wrote a spurious `scrollTop: 0` while detached, clobbering the saved position.

Defer restore/permalink until an element is attached (without recording it applied), and skip persisting while detached. Adds DOM tests for lazy mount.