### PR TITLE
Make core library-agnostic while preserving everything else

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,10 @@ Features:
   `createHistoryScrollState`, `createStickToBottom`. Same options and
   snapshot shape as React, with accessors in the reactive slots (query
   functions are bound via `@rocicorp/zero/solid`).
-- **`@rocicorp/zero-virtual/core`** — the framework-agnostic
-  `ZeroVirtualizer` the wrappers share. **Experimental: this entry point is
+- **`@rocicorp/zero-virtual/core`** — the framework- and library-agnostic
+  `ZeroVirtualizer` the wrappers share. It has no dependency on
+  `@rocicorp/zero` — the query types are opaque generics — so bindings can
+  pair it with any fetching library. **Experimental: this entry point is
   public so you can build bindings for other frameworks, but its API may
   change in breaking ways in any release while it settles.**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rocicorp/zero-virtual",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Infinite Virtual Scroller for Zero",
   "keywords": [
     "infinite",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,9 @@
     "solid-js": "^1.9.4"
   },
   "peerDependenciesMeta": {
+    "@rocicorp/zero": {
+      "optional": true
+    },
     "react": {
       "optional": true
     },

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,5 +1,7 @@
 /**
- * Framework-agnostic core of `@rocicorp/zero-virtual`.
+ * Framework- and library-agnostic core of `@rocicorp/zero-virtual`. Nothing
+ * here depends on `@rocicorp/zero`: the query types are opaque generics, so
+ * wrappers can bind the core to any fetching library.
  *
  * @experimental This entry point is public but UNSTABLE: it exists so
  * framework wrappers (react, solid, yours) can share one implementation, and
@@ -67,7 +69,6 @@ export type {
   AnchoringMode,
   GetPageQuery,
   GetPageQueryOptions,
-  GetQueryReturnType,
   GetSingleQuery,
   GetSingleQueryOptions,
   QueryOptions,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -71,10 +71,8 @@ export type {
   GetPageQueryOptions,
   GetSingleQuery,
   GetSingleQueryOptions,
-  QueryOptions,
   QueryResult,
   RowKey,
   ScrollHistoryState,
-  TTL,
   VirtualRow,
 } from './types.ts';

--- a/src/core/rows.ts
+++ b/src/core/rows.ts
@@ -63,10 +63,10 @@ function isPermalink<TStartRow>(
  * Stage 1: the single-row lookup (permalink anchors only; null otherwise so
  * wrappers can keep a stable query slot).
  */
-export function buildSingleQuery<TQuery, TStartRow>(
+export function buildSingleQuery<TQuery, TOptions, TStartRow>(
   inputs: RowsQueryInputs<TStartRow>,
-  getSingleQuery: GetSingleQuery<TQuery>,
-): QueryResult<TQuery> | null {
+  getSingleQuery: GetSingleQuery<TQuery, TOptions>,
+): QueryResult<TQuery, TOptions> | null {
   return isPermalink(inputs.anchor)
     ? getSingleQuery({id: inputs.anchor.id, settled: inputs.settled})
     : null;
@@ -76,12 +76,12 @@ export function buildSingleQuery<TQuery, TStartRow>(
  * Stage 2: the main page query — page-before rows for a permalink (depends on
  * stage 1's result), or the whole page for forward/backward anchors.
  */
-export function buildMainQuery<TQuery, TStartRow>(
+export function buildMainQuery<TQuery, TOptions, TStartRow>(
   inputs: RowsQueryInputs<TStartRow>,
-  getPageQuery: GetPageQuery<TQuery, TStartRow>,
+  getPageQuery: GetPageQuery<TQuery, TOptions, TStartRow>,
   singleStart: TStartRow | null,
   permalinkNotFound: boolean,
-): QueryResult<TQuery> | null {
+): QueryResult<TQuery, TOptions> | null {
   const {anchor, pageSize, settled} = inputs;
   if (isPermalink(anchor)) {
     assert(pageSize % 2 === 0);
@@ -106,12 +106,12 @@ export function buildMainQuery<TQuery, TStartRow>(
  * Stage 3: the page-after query (permalink anchors only; depends on stage 1's
  * result).
  */
-export function buildAfterQuery<TQuery, TStartRow>(
+export function buildAfterQuery<TQuery, TOptions, TStartRow>(
   inputs: RowsQueryInputs<TStartRow>,
-  getPageQuery: GetPageQuery<TQuery, TStartRow>,
+  getPageQuery: GetPageQuery<TQuery, TOptions, TStartRow>,
   singleStart: TStartRow | null,
   permalinkNotFound: boolean,
-): QueryResult<TQuery> | null {
+): QueryResult<TQuery, TOptions> | null {
   const {anchor, pageSize, settled} = inputs;
   if (!isPermalink(anchor)) return null;
   assert(pageSize % 2 === 0);

--- a/src/core/rows.ts
+++ b/src/core/rows.ts
@@ -63,10 +63,10 @@ function isPermalink<TStartRow>(
  * Stage 1: the single-row lookup (permalink anchors only; null otherwise so
  * wrappers can keep a stable query slot).
  */
-export function buildSingleQuery<TRow, TStartRow>(
+export function buildSingleQuery<TQuery, TStartRow>(
   inputs: RowsQueryInputs<TStartRow>,
-  getSingleQuery: GetSingleQuery<TRow>,
-): QueryResult<TRow | undefined> | null {
+  getSingleQuery: GetSingleQuery<TQuery>,
+): QueryResult<TQuery> | null {
   return isPermalink(inputs.anchor)
     ? getSingleQuery({id: inputs.anchor.id, settled: inputs.settled})
     : null;
@@ -76,12 +76,12 @@ export function buildSingleQuery<TRow, TStartRow>(
  * Stage 2: the main page query — page-before rows for a permalink (depends on
  * stage 1's result), or the whole page for forward/backward anchors.
  */
-export function buildMainQuery<TRow, TStartRow>(
+export function buildMainQuery<TQuery, TStartRow>(
   inputs: RowsQueryInputs<TStartRow>,
-  getPageQuery: GetPageQuery<TRow, TStartRow>,
+  getPageQuery: GetPageQuery<TQuery, TStartRow>,
   singleStart: TStartRow | null,
   permalinkNotFound: boolean,
-): QueryResult<TRow> | null {
+): QueryResult<TQuery> | null {
   const {anchor, pageSize, settled} = inputs;
   if (isPermalink(anchor)) {
     assert(pageSize % 2 === 0);
@@ -106,12 +106,12 @@ export function buildMainQuery<TRow, TStartRow>(
  * Stage 3: the page-after query (permalink anchors only; depends on stage 1's
  * result).
  */
-export function buildAfterQuery<TRow, TStartRow>(
+export function buildAfterQuery<TQuery, TStartRow>(
   inputs: RowsQueryInputs<TStartRow>,
-  getPageQuery: GetPageQuery<TRow, TStartRow>,
+  getPageQuery: GetPageQuery<TQuery, TStartRow>,
   singleStart: TStartRow | null,
   permalinkNotFound: boolean,
-): QueryResult<TRow> | null {
+): QueryResult<TQuery> | null {
   const {anchor, pageSize, settled} = inputs;
   if (!isPermalink(anchor)) return null;
   assert(pageSize % 2 === 0);

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,16 +1,4 @@
 /**
- * Zero's query time-to-live. Replicated structurally (`@rocicorp/zero` doesn't
- * export it from its root entry, and this package's core must stay
- * framework- and library-free) — assignable to the `ttl` of both the react
- * and solid `UseQueryOptions`.
- */
-export type TTL =
-  | `${number}${'s' | 'm' | 'h' | 'd' | 'y'}`
-  | 'forever'
-  | 'none'
-  | number;
-
-/**
  * Stable per-row key (row id when loaded, index-derived otherwise). Kept
  * framework-free — assignable to React's `Key` and usable directly in Solid.
  */
@@ -39,15 +27,6 @@ export type Anchor<TStartRow> =
     }>;
 
 /**
- * Per-query options, framework-free. Structurally assignable to the
- * `UseQueryOptions` of both `@rocicorp/zero/react` and `@rocicorp/zero/solid`.
- */
-export type QueryOptions = {
-  enabled?: boolean | undefined;
-  ttl?: TTL | undefined;
-};
-
-/**
  * Result returned by query functions: a query plus optional per-query options.
  *
  * The query is opaque to the core — `TQuery` is whatever query/request type
@@ -57,9 +36,9 @@ export type QueryOptions = {
  *
  * @typeParam TQuery - The query type consumed by the wrapper's data layer
  */
-export type QueryResult<TQuery> = {
+export type QueryResult<TQuery, TOptions> = {
   query: TQuery;
-  options?: QueryOptions;
+  options?: TOptions;
 };
 
 /**
@@ -85,9 +64,9 @@ export type GetPageQueryOptions<TStartRow> = {
  *   (opaque to the core; see {@link QueryResult})
  * @typeParam TStartRow - The type of data needed to anchor pagination
  */
-export type GetPageQuery<TQuery, TStartRow> = (
+export type GetPageQuery<TQuery, TOptions, TStartRow> = (
   options: GetPageQueryOptions<TStartRow>,
-) => QueryResult<TQuery>;
+) => QueryResult<TQuery, TOptions>;
 
 /**
  * Options passed to {@link GetSingleQuery}.
@@ -105,9 +84,9 @@ export type GetSingleQueryOptions = {
  * @typeParam TQuery - The query type consumed by the wrapper's data layer
  *   (opaque to the core; see {@link QueryResult})
  */
-export type GetSingleQuery<TQuery> = (
+export type GetSingleQuery<TQuery, TOptions> = (
   options: GetSingleQueryOptions,
-) => QueryResult<TQuery>;
+) => QueryResult<TQuery, TOptions>;
 
 /**
  * The query wiring the framework bindings add on top of the core options.
@@ -121,15 +100,21 @@ export type GetSingleQuery<TQuery> = (
  * @typeParam TPageQuery - The query type returned by `getPageQuery`
  * @typeParam TSingleQuery - The query type returned by `getSingleQuery`
  */
-export type VirtualizerQueryOptions<TRow, TStartRow, TPageQuery, TSingleQuery> =
-  {
-    /** Function that returns a query for fetching a page of rows */
-    getPageQuery: GetPageQuery<TPageQuery, TStartRow>;
-    /** Function that returns a query for fetching a single row by ID */
-    getSingleQuery: GetSingleQuery<TSingleQuery>;
-    /** Function to extract the start row data from a full row (for pagination anchoring) */
-    toStartRow: (row: TRow) => TStartRow;
-  };
+export type VirtualizerQueryOptions<
+  TRow,
+  TStartRow,
+  TPageQuery,
+  TPageOptions,
+  TSingleQuery,
+  TSingleOptions,
+> = {
+  /** Function that returns a query for fetching a page of rows */
+  getPageQuery: GetPageQuery<TPageQuery, TPageOptions, TStartRow>;
+  /** Function that returns a query for fetching a single row by ID */
+  getSingleQuery: GetSingleQuery<TSingleQuery, TSingleOptions>;
+  /** Function to extract the start row data from a full row (for pagination anchoring) */
+  toStartRow: (row: TRow) => TStartRow;
+};
 
 /**
  * A single item to render. Rows are rendered in normal document flow (no

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,14 +1,8 @@
-import type {
-  DefaultContext,
-  DefaultSchema,
-  QueryOrQueryRequest,
-} from '@rocicorp/zero';
-
 /**
  * Zero's query time-to-live. Replicated structurally (`@rocicorp/zero` doesn't
  * export it from its root entry, and this package's core must stay
- * framework-free) — assignable to the `ttl` of both the react and solid
- * `UseQueryOptions`.
+ * framework- and library-free) — assignable to the `ttl` of both the react
+ * and solid `UseQueryOptions`.
  */
 export type TTL =
   | `${number}${'s' | 'm' | 'h' | 'd' | 'y'}`
@@ -53,9 +47,18 @@ export type QueryOptions = {
   ttl?: TTL | undefined;
 };
 
-/** Result returned by query functions: a query plus optional per-query options. */
-export type QueryResult<TReturn> = {
-  query: GetQueryReturnType<TReturn>;
+/**
+ * Result returned by query functions: a query plus optional per-query options.
+ *
+ * The query is opaque to the core — `TQuery` is whatever query/request type
+ * the consumer's fetching library uses. The `./react` and `./solid` entry
+ * points instantiate it with a Zero query (see `zero-types.ts`); a custom
+ * wrapper can use any other library's type.
+ *
+ * @typeParam TQuery - The query type consumed by the wrapper's data layer
+ */
+export type QueryResult<TQuery> = {
+  query: TQuery;
   options?: QueryOptions;
 };
 
@@ -78,12 +81,13 @@ export type GetPageQueryOptions<TStartRow> = {
 /**
  * Function that returns a query for fetching a page of rows.
  *
- * @typeParam TRow - The type of row data returned from queries
+ * @typeParam TQuery - The query type consumed by the wrapper's data layer
+ *   (opaque to the core; see {@link QueryResult})
  * @typeParam TStartRow - The type of data needed to anchor pagination
  */
-export type GetPageQuery<TRow, TStartRow> = (
+export type GetPageQuery<TQuery, TStartRow> = (
   options: GetPageQueryOptions<TStartRow>,
-) => QueryResult<TRow>;
+) => QueryResult<TQuery>;
 
 /**
  * Options passed to {@link GetSingleQuery}.
@@ -98,44 +102,34 @@ export type GetSingleQueryOptions = {
 /**
  * Function that returns a query for fetching a single row by ID.
  *
- * @typeParam TRow - The type of row data returned from queries
+ * @typeParam TQuery - The query type consumed by the wrapper's data layer
+ *   (opaque to the core; see {@link QueryResult})
  */
-export type GetSingleQuery<TRow> = (
+export type GetSingleQuery<TQuery> = (
   options: GetSingleQueryOptions,
-) => QueryResult<TRow | undefined>;
+) => QueryResult<TQuery>;
 
 /**
- * The query wiring the framework bindings add on top of the core options
- * (the query functions are bound via `@rocicorp/zero/react` or
- * `@rocicorp/zero/solid`).
+ * The query wiring the framework bindings add on top of the core options.
+ * The query types are opaque here — the `./react` and `./solid` entry points
+ * instantiate them with Zero queries (bound via `@rocicorp/zero/react` or
+ * `@rocicorp/zero/solid`); a custom wrapper can use any other library's
+ * query type.
  *
  * @typeParam TRow - The type of row data returned from queries
  * @typeParam TStartRow - The type of data needed to anchor pagination
+ * @typeParam TPageQuery - The query type returned by `getPageQuery`
+ * @typeParam TSingleQuery - The query type returned by `getSingleQuery`
  */
-export type VirtualizerQueryOptions<TRow, TStartRow> = {
-  /** Function that returns a query for fetching a page of rows */
-  getPageQuery: GetPageQuery<TRow, TStartRow>;
-  /** Function that returns a query for fetching a single row by ID */
-  getSingleQuery: GetSingleQuery<TRow>;
-  /** Function to extract the start row data from a full row (for pagination anchoring) */
-  toStartRow: (row: TRow) => TStartRow;
-};
-
-/**
- * Return type of a Zero query or query request.
- *
- * @typeParam TReturn - The type of the query return value
- */
-export type GetQueryReturnType<TReturn> = QueryOrQueryRequest<
-  keyof DefaultSchema['tables'] & string,
-  // oxlint-disable-next-line no-explicit-any
-  any, // input
-  // oxlint-disable-next-line no-explicit-any
-  any, // output
-  DefaultSchema,
-  TReturn,
-  DefaultContext
->;
+export type VirtualizerQueryOptions<TRow, TStartRow, TPageQuery, TSingleQuery> =
+  {
+    /** Function that returns a query for fetching a page of rows */
+    getPageQuery: GetPageQuery<TPageQuery, TStartRow>;
+    /** Function that returns a query for fetching a single row by ID */
+    getSingleQuery: GetSingleQuery<TSingleQuery>;
+    /** Function to extract the start row data from a full row (for pagination anchoring) */
+    toStartRow: (row: TRow) => TStartRow;
+  };
 
 /**
  * A single item to render. Rows are rendered in normal document flow (no

--- a/src/core/virtualizer.ts
+++ b/src/core/virtualizer.ts
@@ -170,13 +170,22 @@ export type VirtualizerBindingOptions<
   TRow,
   TStartRow,
   TPageQuery,
+  TPageOptions,
   TSingleQuery,
+  TSingleOptions,
 > = Omit<
   VirtualizerOptions<TListContextParams, TRow, TStartRow>,
   'observeElementRect' | 'observeElementOffset'
 > &
   VirtualizerScrollOptions &
-  VirtualizerQueryOptions<TRow, TStartRow, TPageQuery, TSingleQuery>;
+  VirtualizerQueryOptions<
+    TRow,
+    TStartRow,
+    TPageQuery,
+    TPageOptions,
+    TSingleQuery,
+    TSingleOptions
+  >;
 
 /**
  * What the framework bindings return: the snapshot plus, TanStack-style, the

--- a/src/core/virtualizer.ts
+++ b/src/core/virtualizer.ts
@@ -161,15 +161,22 @@ export type VirtualizerSnapshot<TRow> = {
  * The full options the framework bindings accept: the core options plus the
  * scroll wiring ({@linkcode VirtualizerScrollOptions}, which also makes the
  * observers optional — the bindings default them per entry-point variant)
- * and the query functions ({@linkcode VirtualizerQueryOptions}).
+ * and the query functions ({@linkcode VirtualizerQueryOptions}, whose query
+ * types are opaque to the core — the bindings instantiate them with their
+ * data layer's query type).
  */
-export type VirtualizerBindingOptions<TListContextParams, TRow, TStartRow> =
-  Omit<
-    VirtualizerOptions<TListContextParams, TRow, TStartRow>,
-    'observeElementRect' | 'observeElementOffset'
-  > &
-    VirtualizerScrollOptions &
-    VirtualizerQueryOptions<TRow, TStartRow>;
+export type VirtualizerBindingOptions<
+  TListContextParams,
+  TRow,
+  TStartRow,
+  TPageQuery,
+  TSingleQuery,
+> = Omit<
+  VirtualizerOptions<TListContextParams, TRow, TStartRow>,
+  'observeElementRect' | 'observeElementOffset'
+> &
+  VirtualizerScrollOptions &
+  VirtualizerQueryOptions<TRow, TStartRow, TPageQuery, TSingleQuery>;
 
 /**
  * What the framework bindings return: the snapshot plus, TanStack-style, the

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -13,15 +13,17 @@ export {
 } from '../core/scroll.ts';
 export type {
   AnchoringMode,
-  GetPageQuery,
   GetPageQueryOptions,
-  GetQueryReturnType,
-  GetSingleQuery,
   GetSingleQueryOptions,
-  QueryResult,
   ScrollHistoryState,
   VirtualRow,
 } from '../core/types.ts';
+export type {
+  GetPageQuery,
+  GetQueryReturnType,
+  GetSingleQuery,
+  QueryResult,
+} from '../zero-types.ts';
 export {useHistoryScrollState} from './use-history-scroll-state.ts';
 export {useStickToBottom, type StickOptions} from './use-stick-to-edge.ts';
 export {

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -23,6 +23,7 @@ export type {
   GetQueryReturnType,
   GetSingleQuery,
   QueryResult,
+  QueryOptions,
 } from '../zero-types.ts';
 export {useHistoryScrollState} from './use-history-scroll-state.ts';
 export {useStickToBottom, type StickOptions} from './use-stick-to-edge.ts';

--- a/src/react/use-rows.ts
+++ b/src/react/use-rows.ts
@@ -8,7 +8,8 @@ import {
   permalinkMissing,
   type RowsSnapshot,
 } from '../core/rows.ts';
-import type {Anchor, GetPageQuery, GetSingleQuery} from '../core/types.ts';
+import type {Anchor} from '../core/types.ts';
+import type {GetPageQuery, GetSingleQuery} from '../zero-types.ts';
 
 /**
  * Internal hook that binds the virtualizer's staged queries to Zero's React

--- a/src/react/use-zero-virtualizer.ts
+++ b/src/react/use-zero-virtualizer.ts
@@ -12,9 +12,9 @@ import {
 import {
   virtualizerResult,
   ZeroVirtualizer,
-  type VirtualizerBindingOptions,
   type VirtualizerResult,
 } from '../core/virtualizer.ts';
+import type {VirtualizerBindingOptions} from '../zero-types.ts';
 import {useRows} from './use-rows.ts';
 
 /**

--- a/src/solid/create-rows.ts
+++ b/src/solid/create-rows.ts
@@ -9,7 +9,7 @@ import {
   type RowsQueryInputs,
   type RowsSnapshot,
 } from '../core/rows.ts';
-import type {GetPageQuery, GetSingleQuery} from '../core/types.ts';
+import type {GetPageQuery, GetSingleQuery} from '../zero-types.ts';
 
 /**
  * Binds the virtualizer's staged queries to Zero's Solid bindings. All

--- a/src/solid/create-zero-virtualizer.ts
+++ b/src/solid/create-zero-virtualizer.ts
@@ -21,9 +21,9 @@ import type {VirtualRow} from '../core/types.ts';
 import {
   virtualizerResult,
   ZeroVirtualizer,
-  type VirtualizerBindingOptions,
   type VirtualizerResult,
 } from '../core/virtualizer.ts';
+import type {VirtualizerBindingOptions} from '../zero-types.ts';
 import {createRows} from './create-rows.ts';
 
 /**

--- a/src/solid/index.ts
+++ b/src/solid/index.ts
@@ -1,12 +1,14 @@
 export type {
-  GetPageQuery,
   GetPageQueryOptions,
-  GetQueryReturnType,
-  GetSingleQuery,
   GetSingleQueryOptions,
   QueryOptions,
-  QueryResult,
 } from '../core/types.ts';
+export type {
+  GetPageQuery,
+  GetQueryReturnType,
+  GetSingleQuery,
+  QueryResult,
+} from '../zero-types.ts';
 export {
   observeElementOffset,
   observeElementRect,

--- a/src/solid/index.ts
+++ b/src/solid/index.ts
@@ -1,13 +1,13 @@
 export type {
   GetPageQueryOptions,
   GetSingleQueryOptions,
-  QueryOptions,
 } from '../core/types.ts';
 export type {
   GetPageQuery,
   GetQueryReturnType,
   GetSingleQuery,
   QueryResult,
+  QueryOptions,
 } from '../zero-types.ts';
 export {
   observeElementOffset,

--- a/src/zero-types.ts
+++ b/src/zero-types.ts
@@ -11,6 +11,27 @@ import type {
 import type {VirtualizerBindingOptions as CoreVirtualizerBindingOptions} from './core/virtualizer.ts';
 
 /**
+ * Zero's query time-to-live. Replicated structurally (`@rocicorp/zero` doesn't
+ * export it from its root entry, and this package's core must stay
+ * framework- and library-free) — assignable to the `ttl` of both the react
+ * and solid `UseQueryOptions`.
+ */
+export type TTL =
+  | `${number}${'s' | 'm' | 'h' | 'd' | 'y'}`
+  | 'forever'
+  | 'none'
+  | number;
+
+/**
+ * Per-query options, framework-free. Structurally assignable to the
+ * `UseQueryOptions` of both `@rocicorp/zero/react` and `@rocicorp/zero/solid`.
+ */
+export type QueryOptions = {
+  enabled?: boolean | undefined;
+  ttl?: TTL | undefined;
+};
+
+/**
  * The Zero instantiations of the core's query-agnostic types, shared by the
  * `./react` and `./solid` entry points. The core itself is library-agnostic
  * (its query types are opaque generics); this module pins them to Zero
@@ -40,7 +61,10 @@ export type GetQueryReturnType<TReturn> = QueryOrQueryRequest<
  *
  * @typeParam TReturn - The type of the query return value
  */
-export type QueryResult<TReturn> = CoreQueryResult<GetQueryReturnType<TReturn>>;
+export type QueryResult<TReturn> = CoreQueryResult<
+  GetQueryReturnType<TReturn>,
+  QueryOptions
+>;
 
 /**
  * Function that returns a Zero query for fetching a page of rows.
@@ -50,6 +74,7 @@ export type QueryResult<TReturn> = CoreQueryResult<GetQueryReturnType<TReturn>>;
  */
 export type GetPageQuery<TRow, TStartRow> = CoreGetPageQuery<
   GetQueryReturnType<TRow>,
+  QueryOptions,
   TStartRow
 >;
 
@@ -59,7 +84,8 @@ export type GetPageQuery<TRow, TStartRow> = CoreGetPageQuery<
  * @typeParam TRow - The type of row data returned from queries
  */
 export type GetSingleQuery<TRow> = CoreGetSingleQuery<
-  GetQueryReturnType<TRow | undefined>
+  GetQueryReturnType<TRow | undefined>,
+  QueryOptions
 >;
 
 /**
@@ -76,5 +102,7 @@ export type VirtualizerBindingOptions<TListContextParams, TRow, TStartRow> =
     TRow,
     TStartRow,
     GetQueryReturnType<TRow>,
-    GetQueryReturnType<TRow | undefined>
+    QueryOptions,
+    GetQueryReturnType<TRow | undefined>,
+    QueryOptions
   >;

--- a/src/zero-types.ts
+++ b/src/zero-types.ts
@@ -1,0 +1,80 @@
+import type {
+  DefaultContext,
+  DefaultSchema,
+  QueryOrQueryRequest,
+} from '@rocicorp/zero';
+import type {
+  GetPageQuery as CoreGetPageQuery,
+  GetSingleQuery as CoreGetSingleQuery,
+  QueryResult as CoreQueryResult,
+} from './core/types.ts';
+import type {VirtualizerBindingOptions as CoreVirtualizerBindingOptions} from './core/virtualizer.ts';
+
+/**
+ * The Zero instantiations of the core's query-agnostic types, shared by the
+ * `./react` and `./solid` entry points. The core itself is library-agnostic
+ * (its query types are opaque generics); this module pins them to Zero
+ * queries so the bindings' public API is expressed in terms of the row type,
+ * exactly as before.
+ */
+
+/**
+ * Return type of a Zero query or query request.
+ *
+ * @typeParam TReturn - The type of the query return value
+ */
+export type GetQueryReturnType<TReturn> = QueryOrQueryRequest<
+  keyof DefaultSchema['tables'] & string,
+  // oxlint-disable-next-line no-explicit-any
+  any, // input
+  // oxlint-disable-next-line no-explicit-any
+  any, // output
+  DefaultSchema,
+  TReturn,
+  DefaultContext
+>;
+
+/**
+ * Result returned by query functions: a Zero query plus optional per-query
+ * options.
+ *
+ * @typeParam TReturn - The type of the query return value
+ */
+export type QueryResult<TReturn> = CoreQueryResult<GetQueryReturnType<TReturn>>;
+
+/**
+ * Function that returns a Zero query for fetching a page of rows.
+ *
+ * @typeParam TRow - The type of row data returned from queries
+ * @typeParam TStartRow - The type of data needed to anchor pagination
+ */
+export type GetPageQuery<TRow, TStartRow> = CoreGetPageQuery<
+  GetQueryReturnType<TRow>,
+  TStartRow
+>;
+
+/**
+ * Function that returns a Zero query for fetching a single row by ID.
+ *
+ * @typeParam TRow - The type of row data returned from queries
+ */
+export type GetSingleQuery<TRow> = CoreGetSingleQuery<
+  GetQueryReturnType<TRow | undefined>
+>;
+
+/**
+ * The core's binding options with the query types pinned to Zero queries
+ * (bound via `@rocicorp/zero/react` or `@rocicorp/zero/solid`).
+ *
+ * @typeParam TListContextParams - The type of parameters that define the list's query context
+ * @typeParam TRow - The type of row data returned from queries
+ * @typeParam TStartRow - The type of data needed to anchor pagination
+ */
+export type VirtualizerBindingOptions<TListContextParams, TRow, TStartRow> =
+  CoreVirtualizerBindingOptions<
+    TListContextParams,
+    TRow,
+    TStartRow,
+    GetQueryReturnType<TRow>,
+    GetQueryReturnType<TRow | undefined>
+  >;


### PR DESCRIPTION
Re-push of #63 (couldn't push to the fork branch); commits re-signed. Original work by @buzinas.

## Related issues

Implements #61.

## Description

This PR makes `core` not only framework-agnostic, but also library-agnostic. Before this PR, `core` depends on `@rocicorp/zero`, but only its types are used opaquely. Now it uses an opaque generic `TQuery` type instead, so any consumer can just pass the query shape their library use.

The types that depended on `@rocicorp/zero` were moved to `src/zero-types.ts` and both `react` and `solid` libraries only change where they import the types from and nothing else.

The goal here is to be able to make `core` compatible not only with Zero, but also with any other fetching library as React Query, Apollo GraphQL etc.

Closes #61 #63 