### PR TITLE
fix(demo,docs): render spaceBefore/spaceAfter as spacers, not padding

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,19 +169,21 @@ export function ItemList() {
     onScrollStateChange,
   });
 
-  // Rows render in normal document flow inside a content wrapper whose
-  // padding stands in for the not-yet-loaded rows above and below (padding
-  // rather than margin so it always contributes to the scrollable extent).
-  // The hook manages `overflow-anchor` on the scroll container per the
-  // anchoring mode.
+  // Rows render in normal document flow inside a content wrapper. The
+  // not-yet-loaded rows above and below are stood in for by spacer elements
+  // sized `spaceBefore` / `spaceAfter`, so scroll anchoring keeps the viewport
+  // stable across paging. The hook manages `overflow-anchor` on the scroll
+  // container per the anchoring mode.
   return (
     <div ref={parentRef} style={{overflow: 'auto', height: '100vh'}}>
-      <div style={{paddingTop: spaceBefore, paddingBottom: spaceAfter}}>
+      <div>
+        <div style={{height: spaceBefore}} />
         {items.map(({index, key, row}) => (
           <div key={key} {...rowAttributes(index, key)}>
             {row ? row.title : 'Loading...'}
           </div>
         ))}
+        <div style={{height: spaceAfter}} />
       </div>
     </div>
   );

--- a/demo/react/App.tsx
+++ b/demo/react/App.tsx
@@ -82,11 +82,12 @@ export function App(): React.ReactNode {
           onToggleSortDirection={toggleSortDirection}
         />
         {/* Scrollable viewport. Rows render in normal flow inside a content
-            wrapper whose padding stands in for the unloaded rows above and
-            below (padding, not margin, so it always contributes to the
-            scrollable extent). */}
+            wrapper. `spaceBefore` / `spaceAfter` stand in for the unloaded rows
+            above and below, rendered as spacer elements so scroll anchoring
+            keeps the viewport stable across paging. */}
         <div ref={parentRef} className={styles.viewport}>
-          <div style={{paddingTop: spaceBefore, paddingBottom: spaceAfter}}>
+          <div>
+            <div style={{height: spaceBefore}} />
             {items.map(item => (
               <ItemRow
                 key={item.key}
@@ -96,6 +97,7 @@ export function App(): React.ReactNode {
                 permalinkID={permalinkID}
               />
             ))}
+            <div style={{height: spaceAfter}} />
           </div>
         </div>
       </div>

--- a/demo/react/WindowList.tsx
+++ b/demo/react/WindowList.tsx
@@ -86,13 +86,12 @@ export function WindowList(): React.ReactNode {
         />
       </div>
 
-      {/* The rows element doubles as the content wrapper: its padding stands
-          in for the unloaded rows above and below (it isn't the scroll
-          container — the window is — so padding on it is safe). */}
-      <div
-        ref={rowsRef}
-        style={{paddingTop: spaceBefore, paddingBottom: spaceAfter}}
-      >
+      {/* The rows element is the content wrapper. `spaceBefore` / `spaceAfter`
+          stand in for the unloaded rows above and below, rendered as spacer
+          elements so scroll anchoring keeps the viewport stable across
+          paging. */}
+      <div ref={rowsRef}>
+        <div style={{height: spaceBefore}} />
         {items.map(item => (
           <ItemRow
             key={item.key}
@@ -102,6 +101,7 @@ export function WindowList(): React.ReactNode {
             permalinkID={permalinkID}
           />
         ))}
+        <div style={{height: spaceAfter}} />
       </div>
       <DevPanel
         getScrollElement={getScrollElement}

--- a/demo/solid/App.tsx
+++ b/demo/solid/App.tsx
@@ -85,15 +85,11 @@ export function App() {
           onToggleSortDirection={toggleSortDirection}
         />
         <div ref={parentRef} class={styles.viewport}>
-          {/* Content wrapper: its padding stands in for the unloaded rows
-              above and below (padding, not margin, so it always contributes
-              to the scrollable extent). */}
-          <div
-            style={{
-              'padding-top': `${virtualizer().spaceBefore}px`,
-              'padding-bottom': `${virtualizer().spaceAfter}px`,
-            }}
-          >
+          {/* Content wrapper. `spaceBefore` / `spaceAfter` stand in for the
+              unloaded rows above and below, rendered as spacer elements so
+              scroll anchoring keeps the viewport stable across paging. */}
+          <div>
+            <div style={{height: `${virtualizer().spaceBefore}px`}} />
             {/* Plain <For> is safe here: the binding exposes items as a store
                 reconciled by row key, so a row's VirtualRow instance — and
                 with it the DOM node scroll anchoring measures against —
@@ -108,6 +104,7 @@ export function App() {
                 />
               )}
             </For>
+            <div style={{height: `${virtualizer().spaceAfter}px`}} />
           </div>
         </div>
       </div>

--- a/src/core/stick-to-bottom.ts
+++ b/src/core/stick-to-bottom.ts
@@ -36,7 +36,7 @@ export type StickToBottomController = {
  * content grows, which is the whole trick), and snap back to the bottom on
  * growth only while stuck. Growth is detected with two ResizeObservers — one
  * on the rows' content wrapper (anything that changes the scrollable extent:
- * rows added, the space estimates re-rendered as padding, a row streaming in
+ * rows added, the space-estimate spacer elements resized, a row streaming in
  * taller) and one on the scroll container (viewport resizes; the window
  * `resize` event when the document itself scrolls). Both fire post-layout,
  * pre-paint, so the re-pin never flickers. No content change notifications

--- a/src/core/virtualizer.ts
+++ b/src/core/virtualizer.ts
@@ -146,6 +146,12 @@ export type VirtualizerOptions<TListContextParams, TRow, TStartRow> = {
  * actually changed. */
 export type VirtualizerSnapshot<TRow> = {
   items: ReadonlyArray<VirtualRow<TRow>>;
+  /**
+   * Pixel extent of the unloaded rows above (`spaceBefore`) and below
+   * (`spaceAfter`) the loaded window. Render each as a spacer element
+   * (`<div style={{height: spaceBefore}} />`) inside the content wrapper, so
+   * scroll anchoring keeps the viewport stable as paging changes the space.
+   */
   spaceBefore: number;
   spaceAfter: number;
   rowAt: (index: number) => TRow | undefined;

--- a/src/react/use-zero-virtualizer.ts
+++ b/src/react/use-zero-virtualizer.ts
@@ -33,7 +33,9 @@ export type UseZeroVirtualizerOptions<TListContextParams, TRow, TStartRow> =
 
 /**
  * Result object returned by the useZeroVirtualizer hook: the loaded rows to
- * render inside a content wrapper padded by `spaceBefore` / `spaceAfter`,
+ * render inside a content wrapper, with `spaceBefore` / `spaceAfter` standing
+ * in for the unloaded rows above and below — rendered as spacer elements (see
+ * {@linkcode VirtualizerResult}),
  * plus load/paging status, the resolved scroll
  * wiring (`options`), and the current scrolling element (`scrollElement`).
  * See {@linkcode VirtualizerResult} for field semantics. The object identity


### PR DESCRIPTION
Native scroll anchoring does not compensate for a padding change on the anchor row's ancestor — verified identical in Chrome, Firefox, and Safari. The recommended pattern applied the space estimates as padding on the rows wrapper, so every paging re-anchor changed that padding uncompensated and the viewport jumped (most visible with tall/variable rows, where the estimate is never exact). A spacer element is a content box, which anchoring does compensate.

Switch the demos (react element + window, solid), the README example, and the option docs to render spaceBefore/spaceAfter as spacer <div>s inside the content wrapper. No API change — the core still returns the numbers; only the recommended rendering changes.

stick-to-bottom is unaffected: it observes firstRow().parentElement's border-box, which grows the same whether the extent is padding or spacer children (React e2e stick + smoothness specs pass).