### PR TITLE
fix(core): skip no-op re-anchors so a below-viewport list doesn't spin

### DIFF
--- a/src/core/virtualizer.dom.test.ts
+++ b/src/core/virtualizer.dom.test.ts
@@ -557,3 +557,31 @@ describe('persist timing', () => {
     expect(persisted.at(-1)!.scrollTop).toBe(300);
   });
 });
+
+describe('no-op re-anchor does not spin the render loop', () => {
+  test('loaded rows entirely below the viewport at scroll-top stay put (window list under other page content)', () => {
+    // Fully loaded, at rest, anchored at the top.
+    const h = harness({rowCount: 5});
+    h.settle();
+    expect(h.core.getSnapshot().complete).toBe(true);
+
+    // Simulate other page content above the list (e.g. zbugs' issue detail
+    // above the window-scrolled comments): every rendered row now sits below
+    // the viewport, and the page is scrolled to the very top (offset 0).
+    h.wrapper.style.marginTop = '1000px';
+
+    // Each commit runs afterDOMUpdate → #evaluatePaging, which finds no row in
+    // the viewport and re-selects the top anchor. That anchor is already the
+    // current one, so it must be a no-op: before the fix it bumped the version
+    // and notified on every commit, which the React binding turns into an
+    // infinite re-render ("Maximum update depth exceeded").
+    let notifies = 0;
+    const unsub = h.core.subscribe(() => notifies++);
+    h.core.afterDOMUpdate();
+    h.core.afterDOMUpdate();
+    h.core.afterDOMUpdate();
+    unsub();
+
+    expect(notifies).toBe(0);
+  });
+});

--- a/src/core/virtualizer.ts
+++ b/src/core/virtualizer.ts
@@ -55,6 +55,28 @@ const createPermalinkAnchor = (id: string) =>
     kind: 'permalink',
   }) as const;
 
+// Whether two anchors select the same query window: same kind and index, and
+// the same start cursor. The cursor — `startRow` for forward/backward
+// (`undefined` for the top anchor), `id` for permalink — is compared by
+// reference. The core deliberately does not compare rows by value: only the
+// data layer knows a row's sort order (Zero has a comparator), and the cursor
+// is the sort columns, not the row key — a key match with different sort
+// values would be a *different* cursor, so a key/value guess could wrongly
+// skip a real re-anchor. Reference equality is the safe conservative signal:
+// unchanged query results hand back the same row object (so a genuine no-op —
+// e.g. re-selecting the top anchor — is caught), and anything else re-anchors.
+function anchorsEqual<TStartRow>(
+  a: Anchor<TStartRow>,
+  b: Anchor<TStartRow>,
+): boolean {
+  if (a === b) return true;
+  if (a.kind !== b.kind || a.index !== b.index) return false;
+  if (a.kind === 'permalink') {
+    return a.id === (b as {id: string}).id;
+  }
+  return a.startRow === (b as {startRow?: TStartRow}).startRow;
+}
+
 /**
  * Pairs the paging anchor with the list-context params (sort/filter) it was
  * created under, so the two can only change together. While they disagree with
@@ -127,6 +149,14 @@ export type VirtualizerOptions<TListContextParams, TRow, TStartRow> = {
    * Rounded up to an even number (paging halves pages around permalinks).
    */
   minPageSize?: number | undefined;
+  /**
+   * Persisted scroll/paging state to restore (e.g. on back/forward). Compared
+   * by reference: pass a **referentially stable** value that changes identity
+   * only when its content changes — otherwise restore re-applies every commit
+   * and paging can't settle. The `useHistoryScrollState` / `createHistoryScrollState`
+   * helpers guarantee this (they memoize by serialized content); a custom
+   * persistence layer must memoize the same way.
+   */
   scrollState?: ScrollHistoryState<TStartRow> | null | undefined;
   onScrollStateChange?:
     | ((state: ScrollHistoryState<TStartRow>) => void)
@@ -719,6 +749,16 @@ export class ZeroVirtualizer<TListContextParams, TRow, TStartRow> {
   // the relabel, so the visible content stays put.
   #setAnchor(anchor: Anchor<TStartRow>, totalDelta = 0): void {
     const s = this.#paging;
+    // Skip a re-anchor that changes nothing. #setPaging only guards by object
+    // identity and this always builds a fresh paging object, so without this a
+    // redundant re-anchor bumps the version → notifies → re-renders → runs
+    // afterDOMUpdate → re-anchors again, an infinite loop. #evaluatePaging hits
+    // this when the loaded rows sit entirely below the viewport at scroll
+    // offset 0 (a window-scrolled list rendered below other page content, at
+    // the top of the page): it re-selects the top anchor every commit.
+    if (totalDelta === 0 && anchorsEqual(s.queryAnchor.anchor, anchor)) {
+      return;
+    }
     this.#setPaging({
       ...s,
       estimatedTotal: s.estimatedTotal + totalDelta,


### PR DESCRIPTION
#setAnchor always builds a fresh paging object and #setPaging only guards by identity, so re-anchoring to the anchor already in effect still bumped the version → notified → re-rendered → ran afterDOMUpdate → re-anchored again: an infinite loop React aborts as "Maximum update depth exceeded".

#evaluatePaging triggers it whenever the loaded rows sit entirely below the viewport at scroll offset 0 — a window-scrolled list rendered below other page content (e.g. zbugs' comments under the issue detail), at the top of the page. firstVisible is Infinity, and the recovery branch re-selects the (already current) top anchor every commit.

Guard #setAnchor with anchorsEqual: same kind and index, and the same start cursor compared by reference. The core does not compare rows by value — only the data layer knows a row's sort order, and the cursor is the sort columns (not the row key), so a key/value guess could wrongly skip a real re-anchor. Reference equality is safe: unchanged query results hand back the same row object, so a genuine no-op is caught while anything else re-anchors. Adds a DOM-harness regression test that counts notifications (3 → 0).