### PR TITLE
fix(core): don't page backward from the start of a below-viewport list

### DIFF
--- a/src/core/virtualizer.dom.test.ts
+++ b/src/core/virtualizer.dom.test.ts
@@ -585,3 +585,24 @@ describe('no-op re-anchor does not spin the render loop', () => {
     expect(notifies).toBe(0);
   });
 });
+
+describe('below-viewport window at the start of the list', () => {
+  test('scrolling while the loaded rows sit below the viewport does not empty them', () => {
+    // Fully-loaded-from-the-top list, complete and at the start.
+    const h = harness({rowCount: 300});
+    h.settle();
+    expect(h.core.getSnapshot().items.length).toBeGreaterThan(0);
+
+    // Other page content above the list: every loaded row renders below the
+    // viewport (a window-scrolled list under a tall header/detail).
+    h.wrapper.style.marginTop = '1000px';
+
+    // The user scrolls down through that content — offset > 0, but the rows are
+    // still below the viewport. #evaluatePaging must NOT page backward from the
+    // start (there is nothing before row 0; that page is empty and would clear
+    // the list). The loaded top-of-list rows must survive.
+    h.userScroll(150);
+    h.settle();
+    expect(h.core.getSnapshot().items.length).toBeGreaterThan(0);
+  });
+});

--- a/src/core/virtualizer.ts
+++ b/src/core/virtualizer.ts
@@ -1404,8 +1404,15 @@ export class ZeroVirtualizer<TListContextParams, TRow, TStartRow> {
       const first = firstRow(el);
       if (!first) return;
       if (first.getBoundingClientRect().top >= elBottom) {
-        // The window is below the viewport — the jump went up.
-        if (this.#scrollOffset(el) <= 0) {
+        // The loaded window is entirely below the viewport. Two ways to get
+        // here: we're at the start of the list, which renders below other page
+        // content (a window-scrolled list under a header/detail) and the user
+        // hasn't scrolled down to it yet — there is nothing to page, the rows
+        // are already loaded and the user scrolls into them; or the viewport
+        // jumped up into the padding above a mid-list window, which pages
+        // backward toward the viewport. Paging backward at the start would
+        // anchor before row 0 and load an empty page, emptying the list.
+        if (this.#scrollOffset(el) <= 0 || rows.atStart) {
           this.#setAnchor(TOP_ANCHOR as Anchor<TStartRow>);
         } else {
           updateAnchorForEdge(rows.firstRowIndex, 'backward', 0);


### PR DESCRIPTION
When the loaded window is entirely below the viewport (a window-scrolled list rendered under other page content, before the user scrolls to it),
 #evaluatePaging's Infinity-recovery branch pages backward toward the viewport.
At the start of the list (rows.atStart) there is nothing before row 0, so that backward page comes back empty and clears the whole list — the comments render, then vanish the moment you scroll.

Only page backward when not at the start; at the start the rows are already loaded and the user reaches them by scrolling down (re-anchor to top, a no-op). Adds a DOM-harness regression test (list survives a scroll while below the viewport).